### PR TITLE
clarify setjmp/longjmp limitations when implemented using exceptions

### DIFF
--- a/EssentialPostV1Features.md
+++ b/EssentialPostV1Features.md
@@ -23,8 +23,13 @@ in [future versions](FutureFeatures.md).
 
 ## Zero-cost Exception Handling
 * Developer access to stack unwinding and inspection.
-* This will be used to implement `setjmp`/`longjmp` (instead of the usual
-  opposite approach).
+* This may be used to implement `setjmp`/`longjmp` (instead of the usual
+  opposite approach). This can enable all of the defined behavior of
+  `setjmp`/`longjmp`, namely unwinding the stack, but does not allow
+  the undefined behavior case of jumping forward to a stack that
+  was already unwound (which is sometimes used to implement coroutines;
+  however, explicit coroutine support is being considered separately
+  anyhow).
 
 ## Signature-restricted Proper Tail Calls
 * This can also be used to support `goto` and irreducible control flow.


### PR DESCRIPTION
@sunfishcode - this is what I was suggesting in that comment, to clarify about setjmp/longjmp. I also changed it to `may` as you suggested. Up to you though, if you don't think the clarification is worth it, just close this.
