### PR TITLE
"linking" instead of "loading"

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -7,8 +7,10 @@ of the [Minimum Viable Product](V1.md) or the
 to be standardized immediately after v.1. These will be prioritized based on
 developer feedback.
 
-## Dynamic loading
- * Both load-time and run-time.
+## Dynamic linking
+ * [Dynamic loading](V1.md#code-loading-and-imports) is in [v.1](V1.md), but all loaded modules have
+   their own [separate heaps](V1.md#heap) and cannot share [function pointers](V1.md#function-pointers).
+ * Support both load-time and run-time (`dlopen`) dynamic linking.
  * TODO
 
 ## Finer-grained control over memory


### PR DESCRIPTION
@jfbastien The idea of this change is that even in v.1 we'll be able to _load_ code any time (b/c ES6 Modules can too), it's the **linking** (where you share heaps and function-pointers) that requires something special.
