### PR TITLE
Add external function pointers

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -13,7 +13,9 @@ This is covered in the [tooling](Tooling.md) section.
 ## Dynamic linking
  * [Dynamic loading](V1.md#code-loading-and-imports) is in [v.1](V1.md), but all loaded modules have
    their own [separate heaps](V1.md#heap) and cannot share [function pointers](V1.md#function-pointers).
- * Support both load-time and run-time (`dlopen`) dynamic linking.
+ * Support both load-time and run-time (`dlopen`) dynamic linking of both
+   WebAssembly modules and non-WebAssembly modules (e.g., on the web, ES6
+   ones containing JS), sharing the heap as well as function pointers.
  * TODO
 
 ## Finer-grained control over memory


### PR DESCRIPTION
It is useful to add function pointers at runtime, that arrive from outside WebAssembly. This is related to dynamic linking, but distinct. For example, qsort might be compiled into WebAssembly, and outside JavaScript might pass in a function at runtime to sort by.

This is very useful for the C++ <-> JS interop story, specifically, when extending a C++ class using JavaScript (the same could be true of C++ <-> other language interop, if not on the web). Specifically, for extension done at runtime, i.e., we don't whether or how many times the class will be extended by JavaScript. Emscripten currently supports this in 3 ways: By "reserving" function pointer space for JS functions to be added; by adding an extra dynamic lookup table; and by "emulating" function tables (i.e., having them outside of the asm module, so that new JS methods can be added directly). Supporting a direct way to add function pointers to outside JS methods would be far superior to all of those.

This is also related to other future features like accessing GC things. Note that a JS function would be just a GC thing, in a sense; the proposal here is to be able to add such GC things as function pointers.

Thoughts?
