### PR TITLE
Relooper clarifications

### DIFF
--- a/V1.md
+++ b/V1.md
@@ -33,10 +33,15 @@ precise descriptions of:
       to asm.js.
  * Control flow is structured (no goto)
   * Simple and size-efficient binary encoding and compilation.
-  * Most (reducible) goto-based control flow can be transformed into structured control flow with a 
-    [relooping](http://mozakai.blogspot.com/2012/05/reloop-all-blocks.html) algorithm.
+  * Any control flow - even irreducible - can be transformed into structured control flow with the 
+    [Relooper](https://github.com/kripken/emscripten/raw/master/docs/paper.pdf)
+    [algorithm](http://dl.acm.org/citation.cfm?id=2048224&CFID=670868333&CFTOKEN=46181900), with
+    guaranteed low code size overhead, and typically minimal throughput overhead (except for
+    pathological cases of irreducible control flow). Alternative approaches can generate reducible
+    control flow via node splitting, which can reduce throughput overhead, at the cost of
+    increasing code size (potentially very significantly in pathological cases).
   * The [signature-restricted proper tail-call](https://github.com/WebAssembly/spec/blob/master/EssentialPostV1Features.md#signature-restricted-proper-tail-calls) 
-    feature would allow efficient compilation of irreducible control flow.
+    feature would allow efficient compilation of arbitrary irreducible control flow.
  * See the [AST Semantics](AstSemantics.md) for descriptions of individual AST nodes.
 
 ## Binary format


### PR DESCRIPTION
Clarifies that relooping is provably able to handle arbitrary irreducible control flow; it just has more throughput overhead when things get pathological. In other words, the AST format we are proposing can work on any possible code, and generally with minimal overhead; it is for more pathological irreducible control flow that proper tail calls are useful (or maybe in a client-side JIT where we want to just emit blocks and not bother with relooping).

Also mention node-splitting approaches, and add links to both the relooper paper and the citation.
