### PR TITLE
Remove floating-point mod, and rename integer mod to remainder.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -120,8 +120,8 @@ and 0 representing false.
   * Int32Mul - signed-less multiplication (lower 32-bits)
   * Int32SDiv - signed division
   * Int32UDiv - unsigned division
-  * Int32SMod - signed modulus
-  * Int32UMod - unsigned modulus
+  * Int32SRem - signed remainder
+  * Int32URem - unsigned remainder
   * Int32And - signed-less logical and
   * Int32Ior - signed-less inclusive or
   * Int32Xor - signed-less exclusive or
@@ -158,7 +158,6 @@ All 64-bit floating point operations conform to the IEEE-754 standard.
   * Float64Sub - subtraction
   * Float64Mul - multiplication
   * Float64Div - division
-  * Float64Mod - modulus
   * Float64Abs - absolute value
   * Float64Ceil - ceiling operation
   * Float64Floor - floor operation
@@ -188,7 +187,6 @@ All 32-bit floating point operations conform to the IEEE-754 standard.
   * Float32Sub - subtraction
   * Float32Mul - multiplication
   * Float32Div - division
-  * Float32Mod - modulus
   * Float32Eq - compare equal
   * Float32Lt - less than
   * Float32Le - less than or equal


### PR DESCRIPTION
Floating-point mod is not in IEEE-754, not implemented in any hardware,
and not in C or C++ or similar languages. It's in asm.js, but probably
only because it's in JS, and it's in JS possibly only because JS Numbers
are intended to be somewhat usable as integers. Floating-point mod does
have use cases, however they can adequately be serviced by the math
library, in whatever form that ends up taking.

This patch also renames integer mod to remainder, since "signed modulus"
in particular is a non-obvious way to describe the mathematical operation
it performs.
