### PR TITLE
Propose (Load,Store)WithOffset

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -74,6 +74,17 @@ semantics. Other possible semantics which are efficiently implementable
 include throwing an exception or allowing out-of-bound reads to return an
 unspecified value.
 
+To enable more aggresive hoisting of bounds checks, heap accesses may also include
+an offset:
+
+  * LoadHeapWithOffset - load a value from the heap at a given index plus a given immediate offset
+  * StoreHeapWithOffset - store a given value to the heap at a given index plus a given immediate offset
+
+The addition of the offset and index is specified to use infinite precision 
+such that an out-of-bounds access never wraps around to an in-bounds access.
+Bounds checking before the final offset addition allows the offset addition
+to easily be folded into the hardware load instruction *and* for groups of loads
+with the same base and different offsets to easily share a single bounds check.
 
 ## Accessing globals
 


### PR DESCRIPTION
This is a proposal for discussion, relevant to the separate heap/OOB discussion in #23.

A minor side benefit is that, because most loads/stores have a non-zero immediate offset (based on a trivial pattern match), the polyfill prototype shows a 4% size win from this opcode (compared to Load(Add(index, Lit(offset)))).
