### PR TITLE
Describe 2 basic loop types

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -35,8 +35,10 @@ are statements.
 
   * Block - a fixed-length sequence of statements
   * If - if statement
-  * While - while statement
-  * For - for statement
+  * Do-While - do while statement, basically a loop with a
+    conditional branch (back to the top of the loop)
+  * Forever - infinite loop statement (like while(1)), basically an
+    unconditional branch (back to the top of the loop)
   * Continue - continue to start of nested loop
   * Break - break to end from nested loop or block
   * Return - return zero or more values from this function


### PR DESCRIPTION
@sunfishcode and I were talking about this and came up with the following suggestion: We can have 2 basic loop types, **do-while and forever**. do-while is the familiar do-while loop, while forever is an infinite loop like while(1):

```
do {
  code();
} while (cond())

forever {
  code();
  // need a break somewhere, or we never exit
  // jumps back up to the top of the forever
}
```

The idea is that there is nice simplicity here. do-while is a loop with a **conditional** branch back to the top, and forever is a loop with an **unconditional** branch back to the top. Together, they capture the important perf cases: Other loops, like `while (cond()) { .. }` can be written as a forever with condition check at the top (and there is no downside to writing it that way in terms of perf). do-while is fundamentally unwriteable as a `while` variant, as by default `while` branches up to the top every time; do-while avoids that and if the condition fails, just falls through and continues to execute code normally.

As more background, Emscripten has optimized while loops to do-while loops for a while, with significant speedups. The optimization is not trivial, since in AST form, we can only move from

```
while (1) {
  ...
  if (cond()) break;
}
```

to

```
do {
  ...
} while (!cond())
```

If we do not have that perfect last line in the AST, Emscripten works hard to generate it (get rid of variables, move stuff around, flip the if-else if there is an else, etc.). Seems best to leave that to the compiler emitting wasm, and let the browser get a nice do-while in fully optimized form.
