### PR TITLE
Add more operations.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -190,8 +190,12 @@ Additional 32-bit integer Operations under consideration:
 
   * Int32SMulHigh - signed multiplication (upper 32-bits)
   * Int32UMulHigh - unsigned multiplication (upper 32-bits)
-  * Int32Clz - count leading zeroes
+  * Int32Clz - count leading zeroes (defined for all values, including 0)
+  * Int32Ctz - count trailing zeroes (defined for all values, including 0)
   * Int32Popcnt - count number of ones
+  * Int32BSwap - reverse bytes (endian conversion)
+  * Int32Rotr - bitwise rotate right
+  * Int32Rotl - bitwise rotate left
   * Int32Not - signed-less one's complement
   * Int32SMin - signed minimum
   * Int32SMax - signed maximum
@@ -213,15 +217,17 @@ All 64-bit floating point operations conform to the IEEE-754 standard.
   * Float64Mul - multiplication
   * Float64Div - division
   * Float64Abs - absolute value
+  * Float64Neg - negation
+  * Float64Copysign - copysign
   * Float64Ceil - ceiling operation
   * Float64Floor - floor operation
   * Float64Eq - compare equal
   * Float64Lt - less than
   * Float64Le - less than or equal
+  * Float64Sqrt - square root
 
 Operations under consideration:
 
-  * Float64Sqrt - square root
 
 ## 32-bit Floating point operations
 
@@ -232,15 +238,16 @@ All 32-bit floating point operations conform to the IEEE-754 standard.
   * Float32Mul - multiplication
   * Float32Div - division
   * Float32Abs - absolute value
+  * Float32Neg - negation
+  * Float32Copysign - copysign
   * Float32Ceil - ceiling operation
   * Float32Floor - floor operation
   * Float32Eq - compare equal
   * Float32Lt - less than
   * Float32Le - less than or equal
+  * Float32Sqrt - square root
 
 Operations under consideration:
-
-  * Float32Sqrt - square root
 
 
 Note that the IEEE 754 standard does not require extended operations


### PR DESCRIPTION
- The following floating-point opcodes are important fundamentals I
  think we should include in the platform from the beginning:
  - Sqrt - All important hardware has sqrt, asm.js has sqrt, there are no
    precision tradeoffs to consider, and it's a commonly used operation.
  - Neg - IEEE-754 requires that negate be a "quiet-computational sign
    bit operation", and while we don't support alternate rounding modes or
    floating-point exceptions, we do have NaNs, so we should have a Neg
    which guarantees to just flip the sign bit.
  - Copysign - Along with Neg and Abs, this finishes the set of IEEE-754
    quiet-computational operations. It is also nice to have this operation
    instead of the synthisized form with reinterpret-casting to integer
    and back so that the value doesn't appear to leave the floating-point
    register file.
- The following items added to "Operations under consideration". They
  aren't directly available in asm.js, so they're not essential for v1,
  but they're worth considering:
  - Int32Ctz - This can be synthesized as popcnt(~x & (x - 1)), but that
    references the input multiple times, which breaks the single-use
    property, so having this as a regular operation is useful.
  - Int32BSwap, Int32Rotr, Int32Rotl - These can be synthesized too, but
    their synthesized forms also reference the input multiple times.
    Either of rotl or rotr can be synthesized in terms of the other, so
    in theory we'd only need one of those if we wanted to keep it minimal.
