### PR TITLE
Mention typed arrays as a GC thing we will want to support

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -39,6 +39,7 @@ This is covered in the [tooling](Tooling.md) section.
  * Initially, things with fixed structure:
    * JS strings
    * JS functions (as callable closures)
+   * Typed Arrays
    * [Typed objects](https://github.com/nikomatsakis/typed-objects-explainer/)
    * DOM objects via WebIDL
  * Perhaps a rooting API for safe reference from the linear address space


### PR DESCRIPTION
Of course, such typed arrays would not be as optimized as the internal memory of the wasm module, but it would still be useful in some situations to be able to receive a reference to a typed array and to operate on it (even with more bounds checks).

Example use cases:
- Typed arrays arriving from a WebSocket or WebRTC
- Typed arrays arriving from IndexedDB
