### PR TITLE
Rename "V1" aka "v.1" to "MVP".

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -8,7 +8,7 @@ The operations available in the AST are defined here in language-independent
 way but closely match operations in many programming languages and are
 efficiently implementable on all modern computers.
 
-Some operations may *trap* under some conditions, as noted below. In v.1,
+Some operations may *trap* under some conditions, as noted below. In the MVP,
 trapping means that execution in the WebAssembly module is terminated and
 abnormal termination is reported to the outside environment. In a browser
 environment, this would translate into a JS exception being thrown. If
@@ -134,13 +134,13 @@ Bounds checking before the final offset addition allows the offset addition
 to easily be folded into the hardware load instruction *and* for groups of loads
 with the same base and different offsets to easily share a single bounds check.
 
-In v.1, the indices are 32-bit unsigned integers. With 
-[64-bit integers](EssentialPostV1Features.md#64-bit-integers) and
+In the MVP, the indices are 32-bit unsigned integers. With
+[64-bit integers](EssentialPostMVPFeatures.md#64-bit-integers) and
 [>4GiB heaps](FutureFeatures.md#heaps-bigger-than-4gib), these nodes would also
 accept 64-bit unsigned integers.
 
-In v.1, heaps are not shared between threads. When
-[threads](EssentialPostV1Features.md#threads) are added as a feature, the basic
+In the MVP, heaps are not shared between threads. When
+[threads](EssentialPostMVPFeatures.md#threads) are added as a feature, the basic
 `LoadHeap`/`StoreHeap` nodes will have the most relaxed semantics specified in
 the memory model and new heap-access nodes will be added with atomic and
 ordering guarantees.
@@ -208,7 +208,7 @@ Direct calls to a function specify the callee by index into a function table.
   * CallDirect - call function directly
 
 Each function has a signature in terms of local types, and calls must match the
-function signature exactly. [Imported functions](V1.md#code-loading-and-imports) 
+function signature exactly. [Imported functions](MVP.md#code-loading-and-imports)
 also have signatures and are added to the same function table and are thus also
 callable via `CallDirect`.
 
@@ -226,11 +226,11 @@ since the heap only provides integer types). For security and safety reasons,
 the integer value of a coerced function-pointer value is an abstract index and
 does not reveal the actual machine code address of the target function.
 
-In v.1 function pointer values are
+In the MVP, function pointer values are
 local to a single module. The [dynamic linking](FutureFeatures.md#dynamic-linking)
 feature is necessary for two modules to pass function pointers back and forth.
 
-Multiple return value calls will be possible, though possibly not in v.1. The
+Multiple return value calls will be possible, though possibly not in the MVP. The
 details of multiple-return-value calls needs clarification. Calling a function
 that returns multiple values will likely have to be a statement that specifies
 multiple local variables to which to assign the corresponding return values.
@@ -400,13 +400,13 @@ Conversion from floating point to integer where IEEE-754 would specify an
 invalid operation exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) traps.
 
-## Post-v.1 intrinsics
+## Post-MVP intrinsics
 
-The following list of intrinsics is being considered for addition after v.1. The
-rationale is that, for v.1, these operations can be statically linked into the
+The following list of intrinsics is being considered for addition after the MVP. The
+rationale is that, for the MVP, these operations can be statically linked into the
 WebAssembly module by the code generator at small size cost and this avoids a
 non-trivial specification burden of their semantics/precision. Adding these
-intrinsics post-v.1 would allow for better high-level backend optimization of
+intrinsics post-MVP would allow for better high-level backend optimization of
 these intrinsics that require builtin knowledge of their semantics. On the other
 hand, a code generator may continue to statically link in its own implementation
 since this provides greater control over precision/performance tradeoffs.

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -1,14 +1,14 @@
 # Binary Encoding
 
 This document describes the binary encoding of the AST nodes defined in the [AST semantics](AstSemantics.md). 
-For the context of this document, see the [Binary format](V1.md#binary-format) section of the [v.1 doc](V1.md).
+For the context of this document, see the [Binary format](MVP.md#binary-format) section of the [MVP doc](MVP.md).
 
 The binary encoding is designed to allow fast startup, which includes reducing download size
 and allow for quick decoding. Considering the matter of reducing download size, we can see
 it as having three layers:
 
  * The **raw** binary encoding itself, natively decoded by the browser, and to be standardized in
-   v.1 of the spec.
+   the MVP of the spec.
  * **Specific** compression to the binary encoding, that is unreasonable to expect a generic
    compression algorithm like gzip to achieve.
    * This is not meant to be standardized, at least not initially, as it can be done with a
@@ -80,7 +80,7 @@ or tagging. This raises the question of how to reconcile the efficient encoding 
 backwards-compatibility goals.
 
 Specifically, we'd like to avoid the situation where a future version of WebAssembly has features 
-F1 and F2 and vendor V1 implements F1, assigning the next logical opcode indices to F1's new 
+F1 and F2 and vendor V1 implements F1, assigning the next logical opcode indices to F1's new
 opcodes, and V2 implements F2, assigning the same next logical opcode indices to F2's new opcodes 
 and now a single binary has ambiguous semantics if it tries to use either F1 or F2. This type of 
 non-linear feature addition is commonplace in JS and Web APIs and is guarded against by 
@@ -99,9 +99,9 @@ conflict-avoidance practices surrounding string names:
   * To avoid (over time) large index-space declaration sections that are largely the same
     between modules, finalized versions of standards would define named baseline index spaces
     that modules could optionally use as a starting point to further refine.
-    * For example, to use all of [v.1](V1.md) plus [SIMD](EssentialPostV1Features.md#fixed-width-simd)
-      the declaration could be "v1" followed by the list of SIMD opcodes used.
-    * This feature would also be most useful for people handwriting the [text format](V1.md#text-format).
+    * For example, to use all of [the MVP](MVP.md) plus [SIMD](EssentialPostMVPFeatures.md#fixed-width-simd)
+      the declaration could be "base" followed by the list of SIMD opcodes used.
+    * This feature would also be most useful for people handwriting the [text format](MVP.md#text-format).
     * However, such a version declaration does not establish a global "version" for the module
       or affect anything outside of the initialization of the index spaces; decoders would
       remain versionless and simply add cases for new *names* (as with current JS parsers).

--- a/EssentialPostMVPFeatures.md
+++ b/EssentialPostMVPFeatures.md
@@ -1,7 +1,7 @@
-# Essential Post-v.1 Features
+# Essential Post-MVP Features
 
 This is a list of essential features that are known to be needed ASAP, but were removed from
-[v.1](V1.md) since there was not (yet) a portably-efficient polyfill via asm.js. There is a much bigger
+[the MVP](MVP.md) since there was not (yet) a portably-efficient polyfill via asm.js. There is a much bigger
 [list of features](FutureFeatures.md) that will be added after this list, prioritized by feedback and
 experience.
 
@@ -23,7 +23,7 @@ experience.
 * Essentially, import [SIMD.js](https://github.com/johnmccutchan/ecmascript_simd).
   * Would be statically typed analogous to [SIMD.js-in-asm.js](http://discourse.specifiction.org/t/request-for-comments-simd-js-in-asm-js).
   * The goal is to both reuse specification of op semantics (with TC39) and backend implementation (same IR nodes)
-  * Track SIMD.js after v.1.
+  * Track SIMD.js after the MVP.
 * SIMD adds new primitive variable/expression types (e.g., `float32x4`) so it has to be part of
   the core semantics.
 * SIMD operations (e.g., `float32x4.add`) could be either builtin ops (no different than int32 add) or

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -1,18 +1,18 @@
-# Feature to add after v.1
+# Feature to add after the MVP
 
 These are features that make sense in the context of the
 [high-level goals](HighLevelGoals.md) of WebAssembly but are not considered part
-of the [Minimum Viable Product](V1.md) or the
-[essential post-v.1 feature set](EssentialPostV1Features.md) which are expected
-to be standardized immediately after v.1. These will be prioritized based on
+of the [Minimum Viable Product](MVP.md) or the
+[essential post-MVP feature set](EssentialPostMVPFeatures.md) which are expected
+to be standardized immediately after the MVP. These will be prioritized based on
 developer feedback.
 
 ## Great tooling support
 This is covered in the [tooling](Tooling.md) section.
 
 ## Dynamic linking
- * [Dynamic loading](V1.md#code-loading-and-imports) is in [v.1](V1.md), but all loaded modules have
-   their own [separate heaps](V1.md#heap) and cannot share [function pointers](V1.md#function-pointers).
+ * [Dynamic loading](MVP.md#code-loading-and-imports) is in [the MVP](MVP.md), but all loaded modules have
+   their own [separate heaps](MVP.md#heap) and cannot share [function pointers](MVP.md#function-pointers).
  * Support both load-time and run-time (`dlopen`) dynamic linking of both
    WebAssembly modules and non-WebAssembly modules (e.g., on the web, ES6
    ones containing JS), sharing the heap as well as function pointers.
@@ -67,7 +67,7 @@ This is covered in the [tooling](Tooling.md) section.
         (conditionally loaded after a feature test)?
 
 ## Source maps integration
- * Add a new source maps [module section type](V1.md#module-structure).
+ * Add a new source maps [module section type](MVP.md#module-structure).
  * Either embed the source maps directly or just a URL from which source maps can be downloaded.
  * Text source maps become intractably large for even moderate-sized compiled codes, so probably
    need to define new binary format for source maps.

--- a/HighLevelGoals.md
+++ b/HighLevelGoals.md
@@ -1,16 +1,16 @@
 # WebAssembly High-Level Goals
 
-1. Define a portable, size- and load-time-efficient [binary format](V1.md#binary-format)
+1. Define a portable, size- and load-time-efficient [binary format](MVP.md#binary-format)
    to serve as a compilation target which can be compiled to execute at native
    speed by taking advantage of common hardware capabilities.
 2. Specify and implement incrementally:
-    * design [v.1](V1.md) of the standard as a Minimum Viable Product with roughly
+    * design [the MVP](MVP.md) of the standard as a Minimum Viable Product with roughly
       the same functionality as [asm.js](http://asmjs.org);
-    * ship an effective [polyfill](V1.md#polyfill) library for v.1 that translates
-      WebAssembly code into asm.js in the client so that WebAssembly v.1 can run on
+    * ship an effective [polyfill](MVP.md#polyfill) library for the MVP that translates
+      WebAssembly code into asm.js in the client so that WebAssembly MVP can run on
       existing browsers at high speeds;
-    * ship a follow-up to v.1 which adds several more
-      [essential features](EssentialPostV1Features.md); and
+    * ship a follow-up to the MVP which adds several more
+      [essential features](EssentialPostMVPFeatures.md); and
     * continue to iteratively specify [additional features](FutureFeatures.md),
       prioritized by feedback and experience, including support for languages other
       than C/C++.
@@ -25,7 +25,7 @@
       to JavaScript; and
     * define a human-editable text format that is convertible to and from the
       binary format, supporting View Source functionality.
-4. Design to support [non-browser environments](V1.md#non-browser-embedding)
+4. Design to support [non-browser environments](MVP.md#non-browser-embedding)
    as well.
 5. Make a great platform:
     * build an [LLVM backend](https://github.com/WebAssembly/llvm) and

--- a/IncompletelySpecifiedBehavior.md
+++ b/IncompletelySpecifiedBehavior.md
@@ -14,8 +14,8 @@ The following is a list of the places where the WebAssembly specification curren
 
  - [NaN bit patterns](AstSemantics.md#floating-point-operations)
 
- - [Races between threads](EssentialPostV1Features.md#threads)
+ - [Races between threads](EssentialPostMVPFeatures.md#threads)
 
- - [Fixed-width SIMD may want some flexibility](EssentialPostV1Features.md#fixed-width-simd)
+ - [Fixed-width SIMD may want some flexibility](EssentialPostMVPFeatures.md#fixed-width-simd)
    - In SIMD.js, floating-point values may or may not have subnormals flushed to zero.
    - In SIMD.js, operations ending in "Approximation" return approximations that may vary between platforms.

--- a/MVP.md
+++ b/MVP.md
@@ -1,11 +1,11 @@
-# v.1
+# MVP
 
-As stated in the [high-level goals](HighLevelGoals.md), v.1 is designed to be a 
+As stated in the [high-level goals](HighLevelGoals.md), MVP is designed to be a
 Minimum Viable Product, basically on par with [asm.js](http://asmjs.org/) in terms
 of functionality. This means that there are important features we *know* we want 
-and need, but are post-v.1; these are in a separate [essential post-v.1 features doc](EssentialPostV1Features.md).
+and need, but are post-MVP; these are in a separate [essential post-MVP features doc](EssentialPostMVPFeatures.md).
 
-This document explains the contents of v.1 at a high-level.  There are also separate docs with more 
+This document explains the contents of the MVP at a high-level.  There are also separate docs with more
 precise descriptions of:
  * the [AST semantics](AstSemantics.md) 
  * the [binary encoding](BinaryEncoding.md)
@@ -37,12 +37,12 @@ precise descriptions of:
   *single* module. The meaning of a call to an import is defined by
   the host environment.
   * In an environment with ES6 modules, there is no special case for when one
-    WebAssembly module imports another: they have separate [heaps](V1.md#heap)
+    WebAssembly module imports another: they have separate [heaps](MVP.md#heap)
     and pointers cannot be passed between the two. Module imports encapsulate
     the importer and importee.
   * In a minimal shell environment, imports could be limited to 
     builtin modules (implemented by the shell) and/or shell scripts.
-  * The [dynamic linking](FutureFeatures.md#dynamic-linking) post-v.1 feature 
+  * The [dynamic linking](FutureFeatures.md#dynamic-linking) post-MVP feature
     would extend the semantics to include multiple modules and thus allow heap
     and pointer sharing. Dynamic linking would be semantically distinct from
     importing, though.
@@ -58,10 +58,10 @@ precise descriptions of:
  * At the top level, a module is ELF-like: a sequence of sections which declare their type and byte-length.
  * Sections with unknown types would be skipped without error. 
  * Standardized section types:
-  * module import section (see [Module imports](V1.md#module-imports) below)
+  * module import section (see [Module imports](MVP.md#module-imports) below)
   * globals section (constants, signatures, variables)
-  * code section (see [Code section](V1.md#code-section) below)
-  * heap initialization section (see [Heap](V1.md#heap) below)
+  * code section (see [Code section](MVP.md#code-section) below)
+  * heap initialization section (see [Heap](MVP.md#heap) below)
 
 ## Code section
  * The code section begins with a table of functions containing the signatures and 
@@ -84,7 +84,7 @@ precise descriptions of:
     pathological cases of irreducible control flow). Alternative approaches can generate reducible
     control flow via node splitting, which can reduce throughput overhead, at the cost of
     increasing code size (potentially very significantly in pathological cases).
-  * The [signature-restricted proper tail-call](https://github.com/WebAssembly/spec/blob/master/EssentialPostV1Features.md#signature-restricted-proper-tail-calls) 
+  * The [signature-restricted proper tail-call](https://github.com/WebAssembly/spec/blob/master/EssentialPostMVPFeatures.md#signature-restricted-proper-tail-calls)
     feature would allow efficient compilation of arbitrary irreducible control flow.
  * See the [AST Semantics](AstSemantics.md) for descriptions of individual AST nodes.
 
@@ -92,7 +92,7 @@ precise descriptions of:
 * The reason we chose a binary format is efficiency: to reduce download size and accelerate
   decoding, thus enabling even very large codebases to have quick startup times.
   * Towards that goal, the binary format will be natively decoded by the browser.
-* The binary format has an equivalent and isomorphic [text format](V1.md#text-format).
+* The binary format has an equivalent and isomorphic [text format](MVP.md#text-format).
   Conversion from one format to the other is both straightforward and causes
   no loss of information in either direction.
 * Do not try to compete with a generic compression algorithm by trying to suck out every last bit;
@@ -114,11 +114,11 @@ precise descriptions of:
 * The purpose of this format is to support:
   * View Source on a WebAssembly module, thus fitting into the Web (where every source can
     be viewed) in a natural way.
-  * Presentation in browser devtools when source maps aren't present (which is necessarily the case with v.1).
+  * Presentation in browser devtools when source maps aren't present (which is necessarily the case with the MVP).
   * Writing WebAssembly code directly for reasons including pedagogical, experimental, debugging, or
     optimization.
 * The text format is equivalent and isomorphic to the
-  [binary format](V1.md#binary-format), see notes there.
+  [binary format](MVP.md#binary-format), see notes there.
 * The text format will be standardized, but only for tooling purposes:
   * Compilers will support this format for `.S` and inline assembly.
   * Debuggers and profilers will present binary code using this textual format.
@@ -131,11 +131,11 @@ precise descriptions of:
 * TODO: there is no real proposal yet
 
 ## Heap
- * In v.1, when a WebAssembly module is loaded, it creates a new heap.
+ * In the MVP, when a WebAssembly module is loaded, it creates a new heap.
    * The [dynamic linking](FutureFeatures.md#dynamic-linking) feature will be necessary for two
-     WebAssembly modules to share the same heap (but sharing with JS is possible in v.1, see below).
+     WebAssembly modules to share the same heap (but sharing with JS is possible in the MVP, see below).
  * Modules can specify heap size and initialization data (data, rodata, bss) in the 
-   [heap-initialization section](V1.md#module-structure).
+   [heap-initialization section](MVP.md#module-structure).
  * Modules can specify whether the heap is growable (via `sbrk`).
  * Modules can optionally export the heap, allowing it to be aliased by JS.
    * JS sees the exported heap as an ArrayBuffer.
@@ -153,7 +153,7 @@ precise descriptions of:
  
 ## Non-browser embedding
  * Host environments can define builtin modules that are implemented natively but can otherwise
-   be imported like [other modules](V1.md#code-loading-and-imports).
+   be imported like [other modules](MVP.md#code-loading-and-imports).
   * For example, a WebAssembly shell might define a builtin `stdio` library with an export `puts`.
   * Another example, in the browser, would be the WebIDL support mentioned in [future features](FutureFeatures.md).
  * Where there is overlap between the browser and popular non-browser environments, a shared spec could be 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ flux.
 A good starting point is the [high-level design goals](HighLevelGoals.md).
 
 We've mapped out features we expect to ship:
- 1. In [V1](V1.md);
- 2. Closely [after V1](EssentialPostV1Features.md);
+ 1. In [the MVP](MVP.md);
+ 2. Closely [after the MVP](EssentialPostMVPFeatures.md);
  3. In [future versions](FutureFeatures.md).
 
 Join us on IRC: `irc://irc.w3.org:6667/#webassembly`.


### PR DESCRIPTION
Following up on discussion in #106, this renames "V1" aka "v.1" to "MVP".

The only thing that makes this more than a simple file rename and a couple search-and-replaces is that I put "the MVP" instead of just "MVP" in some places and not others, following context.
