### PR TITLE
Readme moar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A good starting point is the [high-level design goals](HighLevelGoals.md),
 followed by the [FAQ](FAQ.md).
 
 We've mapped out features we expect to ship:
- 1. In [the Minimum Viable Product](MVP.md) (MVP);
+ 1. In [the Minimum Viable Product (MVP)](MVP.md);
  2. Closely [after the MVP](EssentialPostMVPFeatures.md);
  3. In [future versions](FutureFeatures.md).
 


### PR DESCRIPTION
- Change the title to 'design' instead of 'specification' as discussed in #80. I'll change the actual repo name later.
- Mention that the spec will be elsewhere.
- Clarify that this is tentative.
- Link to the public mailing list, which I expect people will want to use once the repo becomes public (discussion directly on github would be painful).
