### PR TITLE
Remove the ™ from IoT.

### DIFF
--- a/HighLevelGoals.md
+++ b/HighLevelGoals.md
@@ -4,7 +4,7 @@
    [binary format](MVP.md#binary-format) to serve as a compilation target which
    can be compiled to execute at native speed by taking advantage of common
    hardware capabilities available on a wide range of platforms, including
-   mobile and IoT™.
+   mobile and IoT.
 2. Specify and implement incrementally:
     * design [a Minimum Viable Product (MVP)](MVP.md) for the standard with
       roughly the same functionality as [asm.js](http://asmjs.org);


### PR DESCRIPTION
This is meant to refer to the generic acronym
[IoT](http://en.wikipedia.org/wiki/Internet_of_Things) rather than
to make reference to any trademark.
