### PR TITLE
Update URL of polyfill repo to polyfill-prototype-1

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -8,7 +8,7 @@ Why not a stack-, register- or SSA-based bytecode?
 * Smaller binary encoding:
   [JSZap](http://research.microsoft.com/en-us/projects/jszap),
   [Slim Binaries](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.108.1711)
-* [Polyfill prototype](https://github.com/WebAssembly/polyfill) shows simple and
+* [Polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1) shows simple and
   efficient translation to asm.js.
 
 Each function body consists of exactly one statement.
@@ -270,8 +270,9 @@ Expression trees offer significant size reduction by avoiding the need for
 immediate use.  The following primitives provide AST nodes that express
 control flow and thus allow more opportunities to build bigger expression trees
 and further reduce `SetLocal`/`GetLocal` usage (which constitute 30-40% of total 
-bytes in the polyfill prototype). Additionally, these primitives are useful 
-building blocks for WebAssembly-generators (including the JavaScript polyfill).
+bytes in the [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1)).
+Additionally, these primitives are useful building blocks for
+WebAssembly-generators (including the JavaScript polyfill).
 
   * Comma - evaluate and ignore the result of the first operand, evaluate and return the second operand
   * Conditional - basically ternary ?: operator

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -43,14 +43,14 @@ Yes:
 * Large reductions in payload size can still significantly decrease the
   compressed file size.
   * Experimental results from a
-    [polyfill prototype](https://github.com/WebAssembly/polyfill) show the
+    [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1) show the
     gzipped binary format to be about 20-30% smaller than the corresponding
     gzipped asm.js.
 * A binary format that represents the names of variables and functions with raw
   indices instead of strings is much faster to decode: array indexing
   vs. dictionary lookup.
    * Experimental results from a
-     [polyfill prototype](https://github.com/WebAssembly/polyfill) show that
+     [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1) show that
      decoding the binary format is about 23× faster than parsing the
      corresponding asm.js source (using
      [this demo](https://github.com/lukewagner/AngryBotsPacked), comparing

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,12 +3,12 @@
 ## Can the polyfill really be efficient?
 
 Yes, this is a [high-level goal](HighLevelGoals.md) and there is a 
-[prototype](https://github.com/WebAssembly/polyfill) with demos 
+[prototype](https://github.com/WebAssembly/polyfill-prototype-1) with demos 
 [[1](http://lukewagner.github.io/AngryBotsPacked), 
 [2](http://lukewagner.github.io/PlatformerGamePacked)].  Although the 
 [binary format](BinaryEncoding.md) is not yet specified in any detail, the format used 
 by the prototype has promising initial experimental results. To allow direct comparison with asm.js, 
-the prototype has a tool to [pack asm.js](https://github.com/WebAssembly/polyfill/blob/master/src/pack-asmjs.cpp#L3117)
+the prototype has a tool to [pack asm.js](https://github.com/WebAssembly/polyfill-prototype-1/blob/master/src/pack-asmjs.cpp#L3117)
 into the prototype's binary format. Using this tool, we can see significant size savings before and 
 after <code>gzip</code> compression:
 
@@ -17,7 +17,7 @@ after <code>gzip</code> compression:
 | [AngryBots](http://lukewagner.github.io/AngryBotsPacked) | 19MiB | 6.3MiB | 4.1MiB | 3.0MiB |
 | [PlatformerGame](http://lukewagner.github.io/PlatformerGamePacked) | 49MiB | 18MiB | 11MiB | 7.3MiB |
 
-By writing the [decoder prototype in C++](https://github.com/WebAssembly/polyfill/blob/611ec5c8c41b08b112cf064ec49b13bf87e400cd/src/unpack.cpp#L2306) 
+By writing the [decoder prototype in C++](https://github.com/WebAssembly/polyfill-prototype-1/blob/611ec5c8c41b08b112cf064ec49b13bf87e400cd/src/unpack.cpp#L2306) 
 and Emscripten-compiling to asm.js, the polyfill is able to perform the translation to asm.js
 faster than a native JS parser can parse the result (results measured in Firefox 41 
 on an Intel® Xeon® E5-2665 @ 2.40GHz):

--- a/Polyfill.md
+++ b/Polyfill.md
@@ -29,7 +29,7 @@ capabilities, as detailed in the browser embedding
   [Emscripten]: http://emscripten.org
   [asm.js]: http://asmjs.org
   [PNaCl]: http://gonacl.com
-  [polyfill repo]: https://github.com/WebAssembly/polyfill
+  [polyfill repo]: https://github.com/WebAssembly/polyfill-prototype-1
 
 ## Polyfill Deviations
 


### PR DESCRIPTION
It was suggested to rename the polyfill repo to polyfill-prototype-1 to make it clear that the binary format was in no way meant to be a reference for the real spec and that there may be other polyfill prototypes in the future.
