### PR TITLE
Spell "nondeterministic" without a hyphen.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -204,7 +204,7 @@ opportunities provided by each.
       is incoherent and further execution could lead to Bad Things (e.g., XSS
       attacks).
   * To allow for potentially more-efficient heap sandboxing, the semantics could
-    allow for a non-deterministic choice between one of the following when an
+    allow for a nondeterministic choice between one of the following when an
     out-of-bounds access occurred.
     * The ideal trap semantics.
     * Loads return an unspecified value.
@@ -341,7 +341,7 @@ Additional 32-bit integer Operations under consideration:
 Floating point arithmetic follows the IEEE-754 standard, except that:
  - The sign bit and significand bit pattern of any `NaN` value returned from a
    floating point arithmetic operation other than `Neg`, `Abs`, and `Copysign`
-   are computed non-deterministically. In particular, the "`NaN` propagation"
+   are computed nondeterministically. In particular, the "`NaN` propagation"
    section of IEEE-754 is not required. `NaN`s do propagate through arithmetic
    operations according to IEEE-754 rules, the difference here is that they do
    so without necessarily preserving the specific bit patterns of the original

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -145,7 +145,7 @@ include:
   approaches; which of them might be supported by the model?
 * What is the relationship to the "short SIMD" API? "None" may be an acceptable
   answer, but it's something to think about.
-* What non-determinism does this model introduce into the overall platform?
+* What nondeterminism does this model introduce into the overall platform?
 * What happens when code uses long SIMD on a hardware platform which doesn't
   support it? Reasonable options may include emulating it without the benefit of
   hardware acceleration, or indicating a lack of support through feature tests.

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -2,13 +2,13 @@
 
 WebAssembly is a [portable](Portability.md) sandboxed platform with limited,
 local, nondeterminism. 
-  * *Limited*: non-deterministic execution can only occur in a small number of
+  * *Limited*: nondeterministic execution can only occur in a small number of
     well-defined cases (described below) and, in those cases, the implementation
     may select from a limited set of possible behaviors.
-  * *Local*: when non-deterministic execution occurs, the effect is local,
+  * *Local*: when nondeterministic execution occurs, the effect is local,
     there is no "spooky action at a distance".
 
-The limited, local, non-deterministic model implies:
+The limited, local, nondeterministic model implies:
   * Applications can't access data outside the sandbox without going through
     appropriate APIs, or otherwise escape the sandbox.
   * WebAssembly always maintains valid, trusted callstacks; stray pointer writes

--- a/Portability.md
+++ b/Portability.md
@@ -7,7 +7,7 @@ efficiently on a variety of operating systems and instruction set architectures,
 ## Assumptions for Efficient Execution
 
 Execution environments which, despite
-[limited, local, non-determinism](Nondeterminism.md), don't offer
+[limited, local, nondeterminism](Nondeterminism.md), don't offer
 the following characteristics may be able to execute WebAssembly modules
 nonetheless. In some cases they may have to emulate behavior that the host
 hardware or operating system don't offer so that WebAssembly modules execute


### PR DESCRIPTION
"nondeterminism" too. Spellings with and without the hyphen are in
common use, though the hyphenated form is less common. But mainly it's
just nice to be consistent.
