### PR TITLE
Move the note about C/C++ undefined behavior into CAndC++.md.

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -53,6 +53,25 @@ undefined behavior in C or C++ are still bugs when compiling for WebAssembly
 optimizers still assume that undefined behavior won't occur, so such bugs
 can still lead to surprising behavior.
 
+For example, while unaligned memory access is
+[fully defined](AstSemantics.md#Alignment) in WebAssembly, C and C++ compilers
+make no guarantee that a (non-packed) unaligned memory access at the source
+level is harmlessly translated into an unaligned memory access in WebAssembly.
+And in practice, popular C and C++ compilers do optimize on the assumption that
+alignment rules are followed, meaning that they don't always preserve program
+behavior otherwise.
+
+On WebAssembly, the primary invariants
+[are always maintained](Nondeterminism.md). Demons can't actually fly out your
+nose, as that would constitute an escape from the sandbox. And, callstacks can't
+become corrupted.
+
+Other than that, programs which invoke undefined behavior at the source language
+level may be compiled into WebAssembly programs which do anything else,
+including corrupting the contents of the application heap, calling APIs with
+arbitrary parameters, hanging, trapping, or consuming arbitrary amounts of
+resources (within the limits).
+
 [Tools are being developed and ported](Tooling.md) to help developers find
 and fix such bugs in their code.
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -40,12 +40,7 @@ currently admits nondeterminism:
 
  - Environment-dependent resource limits may be exhausted.
 
-## Note for users of C, C++, and similar languages
-
-Some operations which have fully defined behavior in WebAssembly itself may nonetheless have undefined behavior at the source code level. For example, while unaligned memory access is fully defined in WebAssembly, C and C++ compilers make no guarantee that a (non-packed) unaligned memory access at the source level is harmlessly translated into an unaligned memory access in WebAssembly. And in practice, popular C and C++ compilers do optimize on the assumption that alignment rules are followed, meaning that they don't always preserve program behavior otherwise.
-
-On WebAssembly, the primary invariants are always maintained. Demons can't actually fly out your nose, as that would constitute an escape from the sandbox. And, callstacks can't become corrupted.
-
-Other than that, programs which invoke undefined behavior at the source language level may be compiled into WebAssembly programs which do anything else, including corrupting the contents of the application heap, calling APIs with arbitrary parameters, hanging, trapping, or consuming arbitrary amounts of resources (within the limits).
-
-[Tools are being developed and ported](Tooling.md) to help developers find and fix bugs in their code.
+Users of C, C++, and similar languages should be aware that operations which
+have defined or constrained behavior in WebAssembly itself may nonetheless
+still have undefined behavior
+[at the source code level](CAndC++.md#undefined-behavior).


### PR DESCRIPTION
The text fits better there, and this also tidies up Nondeterminism.md.
