### PR TITLE
Describe integer operation trapping with a new rule.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -299,8 +299,8 @@ and 0 representing false.
   * int32.ior - signed-less inclusive or
   * int32.xor - signed-less exclusive or
   * int32.shl - signed-less shift left
-  * int32.shr - unsigned shift right
-  * int32.sar - signed arithmetic shift right
+  * int32.shr - signed-less logical shift right
+  * int32.sar - signed-less arithmetic shift right
   * int32.eq  - signed-less compare equal
   * int32.slt - signed less than
   * int32.sle - signed less than or equal
@@ -310,10 +310,11 @@ and 0 representing false.
   * int32.ctz - count trailing zeroes (defined for all values, including 0)
   * int32.popcnt - count number of ones
 
-Division or remainder by zero traps.
-Signed division overflow (`INT32_MIN / -1`) traps. Signed remainder with a
+Explicitly signed and unsigned operations trap whenever the result cannot be
+represented in the result type. This includes division and remainder by zero,
+and signed division overflow (`INT32_MIN / -1`). Signed remainder with a
 non-zero denominator always returns the correct value, even when the
-corresponding division would trap.
+corresponding division would trap. Signed-less operations never trap.
 
 Shifts interpret their shift count operand as an unsigned value. When the
 shift count is at least the bitwidth of the shift, shl and shr return 0,


### PR DESCRIPTION
The rule is that explicitly signed or unsigned operations trap any time
they can't return the actual result, and signed-less operations never
trap. There's no behavior change here because this covers exactly the
same cases that we already had covered.

The beauty of this rule is that it elides trapping for add, sub, and mul
for now, which would add too much overhead on today's hardware, while
leaving it in place for div and rem, where it isn't as problematic and
where we already had it, while simultaneously leaving a nice opening for
the possible future addition of explicitly signed and unsigned versions
of add, sub, and mul which would trap on overflow (and overflow is
signedness-dependent anyway).

This requires describing the right shifts as signedless; fortunately
there's already a common naming we can use, "logical" and "arithmetic".
