### PR TITLE
Clarify CG membership rules

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -11,10 +11,10 @@ Interested in participating? We suggest you start by:
 2. Joining the IRC channel `irc://irc.w3.org:6667/#webassembly`.
 
 With that background understood and communication set up, feel free to
-[file issues][] in the WebAssembly design repository. Please join the
-[W3C Community Group](https://www.w3.org/community/webassembly/) before sending pull
-requests: it provides the legal framework that protects the work in this
-repository.
+join the [W3C Community Group](https://www.w3.org/community/webassembly/)
+and then [file issues][] or submit pull requests to the WebAssembly design
+repository. The W3C Community Group provides the legal framework that protects
+the work in this repository.
 
 As WebAssembly moves forward we expect to form an official standards body, which
 will have its own contribution process to the specification.


### PR DESCRIPTION
Adrian Batement informed me that CG membership is necessary for issues that end up contributing to the spec as well, so update Contributing.md.