### PR TITLE
Brotli for BinaryEncoding compression

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -30,7 +30,8 @@ Reducing download size, is achieved through three layers:
        [can improve general compression](https://www.rfk.id.au/blog/entry/cromulate-improve-compressibility/).
  * **Generic** compression, such as gzip, already supported in browsers. Other
    compression algorithms being considered and which might be standardized
-   include: LZMA, [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/).
+   include: LZMA, [LZHAM](https://github.com/richgel999/lzham_codec),
+    [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/).
 
 Each of the three layers work to find compression opportunities to the best of
 its abilities, without encroaching upon the subsequent layer's compression

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -28,8 +28,9 @@ Reducing download size, is achieved through three layers:
      * Another example is reordering of functions and some internal nodes, which
        we know does not change semantics, but
        [can improve general compression](https://www.rfk.id.au/blog/entry/cromulate-improve-compressibility/).
- * **Generic** compression, such as gzip, already supported in browsers, or LZMA
-   and other compression algorithms, which might be standardized as well.
+ * **Generic** compression, such as gzip, already supported in browsers. Other
+   compression algorithms being considered and which might be standardized
+   include: LZMA, [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/).
 
 Each of the three layers work to find compression opportunities to the best of
 its abilities, without encroaching upon the subsequent layer's compression


### PR DESCRIPTION
I received a suggestion to support Brotli, and the rationale is pretty solid:

> The WOFF 2.0 team dropped both gzip and lzma to power their latest system with brotli. Because of that, brotli has already found its way to chrome and android. http://www.w3.org/TR/WOFF20ER/
>
> Brotli can compress 5-25 % more than gzip, is a little bit more efficient for small files than LZMA, and decompresses 3-5x faster than LZMA. (Brotli typically compresses less than LZMA for large files -- above 1 MB or so.)
>
> https://github.com/google/brotli
> 
> https://datatracker.ietf.org/doc/draft-alakuijala-brotli/
> 
> Once the specifics for WebAssembly are clear, we could even specialize the context map or the static dictionary for WebAssembly (or you can design WebAssembly it in a way that it takes maximum benefit of the existing brotli context modes -- there are three binary modes and an utf-8 mode).