### PR TITLE
Add a code of ethics and professional conduct

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -22,5 +22,5 @@ or are worried that the code isn't being followed, please
 [procedures][] allowing you to access its ombuds directly and confidentially.
 
   [Code of Ethics and Professional Conduct]: https://www.w3.org/Consortium/cepc
-  [contact the Community Group's chairs]: https://www.w3.org/community/webassembly/participants
+  [contact the Community Group's chairs]: team-webassembly-chairs@w3.org
   [procedures]: https://www.w3.org/Consortium/pwe/#Procedures

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -17,10 +17,10 @@ WebAssembly operates under the W3C's
 
 We hope that our community group act according to these guidelines, and that
 participants hold each other to these high standards. If you have any questions
-or are worried that the code isn't being followed, please
-[contact the Community Group's chairs][]. For very serious concerns, the W3C has
-[procedures][] allowing you to access its ombuds directly and confidentially.
+or are worried that the code isn't being followed, please contact the Community
+Group's chairs at `team-webassembly-chairs@w3.org` (note: this list is also
+visible to W3C staff). For very serious concerns, the W3C has [procedures][]
+allowing you to access its ombuds directly and confidentially.
 
   [Code of Ethics and Professional Conduct]: https://www.w3.org/Consortium/cepc
-  [contact the Community Group's chairs]: team-webassembly-chairs@w3.org
   [procedures]: https://www.w3.org/Consortium/pwe/#Procedures

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -18,7 +18,9 @@ WebAssembly operates under the W3C's
 We hope that our community group act according to these guidelines, and that
 participants hold each other to these high standards. If you have any questions
 or are worried that the code isn't being followed, please
-[contact the Community Group's chairs][].
+[contact the Community Group's chairs][]. For very serious concerns, the W3C has
+[procedures][] allowing you to access its ombuds directly and confidentially.
 
   [Code of Ethics and Professional Conduct]: https://www.w3.org/Consortium/cepc
   [contact the Community Group's chairs]: https://www.w3.org/community/webassembly/participants
+  [procedures]: https://www.w3.org/Consortium/pwe/#Procedures

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,0 +1,24 @@
+# Code of Ethics and Professional Conduct
+
+WebAssembly operates under the W3C's
+[Code of Ethics and Professional Conduct][]:
+
+> W3C is a growing and global community where participants choose to work
+> together, and in that process experience differences in language, location,
+> nationality, and experience. In such a diverse environment, misunderstandings
+> and disagreements happen, which in most cases can be resolved informally. In
+> rare cases, however, behavior can intimidate, harass, or otherwise disrupt one
+> or more people in the community, which W3C will not tolerate.
+>
+> A Code of Ethics and Professional Conduct is useful to define accepted and
+> acceptable behaviors and to promote high standards of professional
+> practice. It also provides a benchmark for self evaluation and acts as a
+> vehicle for better identity of the organization.
+
+We hope that our community group act according to these guidelines, and that
+participants hold each other to these high standards. If you have any questions
+or are worried that the code isn't being followed, please
+[contact the Community Group's chairs][].
+
+  [Code of Ethics and Professional Conduct]: https://www.w3.org/Consortium/cepc
+  [contact the Community Group's chairs]: https://www.w3.org/community/webassembly/participants

--- a/Contributing.md
+++ b/Contributing.md
@@ -7,14 +7,15 @@ interested in using WebAssembly.
 
 Interested in participating? We suggest you start by:
 
-1. Reading the [WebAssembly design][].
-2. Joining the IRC channel `irc://irc.w3.org:6667/#webassembly`.
+1. Acquainting yourself with the
+   [Code of Ethics and Professional Conduct](CodeOfConduct.md).
+2. Reading the [WebAssembly design][].
+3. Joining the IRC channel `irc://irc.w3.org:6667/#webassembly`.
 
 With that background understood and communication set up, feel free to
 [file issues][] in the WebAssembly design repository. Please join the
-[W3C Community Group](https://www.w3.org/community/webassembly/) before sending pull
-requests: it provides the legal framework that protects the work in this
-repository.
+[W3C Community Group][] before sending pull requests: it provides the legal
+framework that protects the work in this repository.
 
 As WebAssembly moves forward we expect to form an official standards body, which
 will have its own contribution process to the specification.
@@ -23,3 +24,4 @@ Happy assembly!
 
   [WebAssembly design]: https://github.com/WebAssembly/design
   [file issues]: https://github.com/WebAssembly/design/issues
+  [W3C Community Group]: https://www.w3.org/community/webassembly/

--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ We've mapped out features we expect to ship:
 Join us:
  * On IRC: `irc://irc.w3.org:6667/#webassembly`
  * [Contribute](Contributing.md)!
+
+When contributing, please follow our
+[Code of Ethics and Professional Conduct](CodeOfConduct.md).


### PR DESCRIPTION
WebAssembly is growing. There haven't been any regretable events, but it's been suggested that we make this community a welcoming one up-front by having a code of ethics and professional conduct.