### PR TITLE
Search and replace "heap" with "memory"

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -40,7 +40,7 @@ called the *Linear memory*, is a contiguous, byte-addressable range of memory
 spanning from offset `0` to `memory_size`. The linear memory can be considered 
 to be a untyped array of bytes which is stored separately from the global variables.
 The linear memory is sandboxed; it does not alias the execution engine's internal
-data structures, the stack, or other process memory.
+data structures, the execution stack, or other process memory.
 All accesses to memory are annotated with a type. The legal types for
 global variables and memory accesses are called *Memory types*.
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -35,9 +35,14 @@ a trap occurs.
 ## Local and Memory types
 
 Individual storage locations in WebAssembly are typed, including global
-variables, local variables, and parameters. The heap itself is not typed, but
-all accesses to the heap are annotated with a type. The legal types for
-global variables and heap accesses are called *Memory types*.
+variables, local variables, and parameters. The main storage of a wasm module, 
+called the *Linear memory*, is a contiguous, byte-addressable range of memory
+spanning from offset `0` to `memory_size`. The linear memory can be considered 
+to be a untyped array of bytes which is stored separately from the global variables.
+The linear memory is sandboxed; it does not alias the execution engine's internal
+data structures, the stack, or other process memory.
+All accesses to memory are annotated with a type. The legal types for
+global variables and memory accesses are called *Memory types*.
 
   * `int8`: 8-bit integer
   * `int16`: 16-bit integer
@@ -95,7 +100,7 @@ perform saturation, trap on overflow, etc.
 
 Each function has a fixed, pre-declared number of local variables which occupy a single
 index space local to the function. Parameters are addressed as local variables. Local
-variables do not have addresses and are not aliased in the globals or the heap. Local
+variables do not have addresses and are not aliased in the globals or memory. Local
 variables have *Local types* and are initialized to the appropriate zero value for their
 type at the beginning of the function, except parameters which are initialized to the values
 of the arguments passed to the function.
@@ -141,26 +146,26 @@ nested. This guarantees that all resulting control flow graphs are well-structur
     feature would allow efficient compilation of arbitrary irreducible control
     flow.
 
-## Accessing the heap
+## Accessing Linear Memory
 
-Programs address the heap by using integers that are interpreted as unsigned byte indexes
+Programs address memory by using integers that are interpreted as unsigned byte indexes
 starting at `0`.
-Accesses to the heap at indices larger than the size of the heap are considered out-of-bounds,
+Accesses to memory at indices larger than the size of memory are considered out-of-bounds,
 and a module may optionally define that out-of-bounds includes small indices close to `0` (see [discussion] (https://github.com/WebAssembly/design/issues/204)).
 Out-of-bounds access is considered a program error, and the semantics are discussed below.
-Each heap access is annotated with a *Memory type* and the presumed alignment of the index.
+Each memory access is annotated with a *Memory type* and the presumed alignment of the index.
 
-  * `load_heap`: load a value from the heap at a given index with given
+  * `load_mem`: load a value from memory at a given index with given
     alignment
-  * `store_heap`: store a given value to the heap at a given index with given
+  * `store_mem`: store a given value to memory at a given index with given
     alignment
 
-To enable more aggressive hoisting of bounds checks, heap accesses may also
+To enable more aggressive hoisting of bounds checks, memory accesses may also
 include an offset:
 
-  * `load_heap_with_offset`: load a value from the heap at a given index plus a
+  * `load_mem_with_offset`: load a value from memory at a given index plus a
     given immediate offset
-  * `store_heap_with_offset`: store a given value to the heap at a given index
+  * `store_mem_with_offset`: store a given value to memory at a given index
     plus a given immediate offset
 
 The addition of the offset and index is specified to use infinite precision such
@@ -171,21 +176,21 @@ same base and different offsets to easily share a single bounds check.
 
 In the MVP, the indices are 32-bit unsigned integers. With
 [64-bit integers](PostMVP.md#64-bit-integers) and
-[>4GiB heaps](FutureFeatures.md#heaps-bigger-than-4gib), these nodes would also
+[>4GiB memory](FutureFeatures.md#heaps-bigger-than-4gib), these nodes would also
 accept 64-bit unsigned integers.
 
-In the MVP, heaps are not shared between threads. When
+In the MVP, linear memory is not shared between threads. When
 [threads](PostMVP.md#threads) are added as a feature, the basic
-`load_heap`/`store_heap` nodes will have the most relaxed semantics specified in
-the memory model and new heap-access nodes will be added with atomic and
+`load_mem`/`store_mem` nodes will have the most relaxed semantics specified in
+the memory model and new memory-access nodes will be added with atomic and
 ordering guarantees.
 
 Two important semantic cases are **misaligned** and **out-of-bounds** accesses:
 
 ### Alignment
 
-If the incoming index argument to a heap access is misaligned with respect to
-the alignment operand of the heap access, the heap access must still work
+If the incoming index argument to a memory access is misaligned with respect to
+the alignment operand of the memory access, the memory access must still work
 correctly (as if the alignment operand was `1`). However, on some platforms,
 such misaligned accesses may incur a *massive* performance penalty (due to trap
 handling). Thus, it is highly recommend that every WebAssembly producer provide
@@ -207,26 +212,26 @@ There are several possible variations on this design being discussed and
 experimented with. More measurement is required to understand the associated tradeoffs.
 
   * After an out-of-bounds access, the module can no longer execute code and any
-    outstanding JS ArrayBuffers aliasing the heap are detached.
+    outstanding JS ArrayBuffers aliasing the linear memory are detached.
     * This would primarily allow hoisting bounds checks above effectful
       operations.
     * This can be viewed as a mild security measure under the assumption that
       while the sandbox is still ensuring safety, the module's internal state
       is incoherent and further execution could lead to Bad Things (e.g., XSS
       attacks).
-  * To allow for potentially more-efficient heap sandboxing, the semantics could
+  * To allow for potentially more-efficient memory sandboxing, the semantics could
     allow for a nondeterministic choice between one of the following when an
     out-of-bounds access occurred.
     * The ideal trap semantics.
     * Loads return an unspecified value.
-    * Stores are either ignored or store to an unspecified location in the heap.
+    * Stores are either ignored or store to an unspecified location in the linear memory.
     * Either tooling or an explicit opt-in "debug mode" in the spec should allow
       execution of a module in a mode that threw exceptions on out-of-bounds
       access.
 
 ## Accessing globals
 
-Global variables are storage locations outside the main heap.
+Global variables are storage locations outside the linear memory.
 Every global has exactly one Memory type.
 Accesses to global variables specify the index as an integer literal.
 
@@ -257,8 +262,8 @@ in the function table.
 
 Function-pointer values are comparable for equality and the `addressof` operator
 is monomorphic. Function-pointer values can be explicitly coerced to and from
-integers (which, in particular, is necessary when loading/storing to the heap
-since the heap only provides integer types). For security and safety reasons,
+integers (which, in particular, is necessary when loading/storing to memory
+since memory only provides integer types). For security and safety reasons,
 the integer value of a coerced function-pointer value is an abstract index and
 does not reveal the actual machine code address of the target function.
 

--- a/CAndC++.md
+++ b/CAndC++.md
@@ -92,7 +92,7 @@ become corrupted.
 
 Other than that, programs which invoke undefined behavior at the source language
 level may be compiled into WebAssembly programs which do anything else,
-including corrupting the contents of the application heap, calling APIs with
+including corrupting the contents of the application's linear memory, calling APIs with
 arbitrary parameters, hanging, trapping, or consuming arbitrary amounts of
 resources (within the limits).
 

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -14,9 +14,9 @@ This is covered in the [tooling](Tooling.md) section.
 ## Dynamic linking
 
 [Dynamic loading](MVP.md#code-loading-and-imports) is in [the MVP](MVP.md), but
-all loaded modules have their own [separate heaps](MVP.md#heap) and cannot share
+all loaded modules have their own [separate linear memory](MVP.md#memory) and cannot share
 [function pointers](MVP.md#function-pointers). Dynamic linking will allow
-developers to share heaps and function pointers between WebAssembly modules.
+developers to share memory and function pointers between WebAssembly modules.
 
 WebAssembly will support both load-time and run-time (`dlopen`) dynamic linking
 of both WebAssembly modules and non-WebAssembly modules (e.g., on the Web, ES6
@@ -77,13 +77,13 @@ Options under consideration:
   * DOM objects via WebIDL.
 * Perhaps a rooting API for safe reference from the linear address space.
 
-## Heaps bigger than 4GiB
+## Linear memory bigger than 4GiB
 
-WebAssembly will eventually allow heaps greater than 4GiB by providing
-load/store operations that take 64-bit address operands. Modules which opt-in to
+WebAssembly will eventually allow a module to have a linear memory size greater than 4GiB by providing
+load/store operations that take 64-bit index operands. Modules which opt-in to
 this feature have `int64` as the canonical pointer type.
 
-On a 32-bit system, heaps must still be smaller than 4GiB. A WebAssembly
+On a 32-bit system, memory must still be smaller than 4GiB. A WebAssembly
 implementation running on such a platform may restrict allocations to the lower
 4GiB, and leave the two 32-bits untouched.
 
@@ -114,7 +114,7 @@ Useful properties of signature-restricted PTCs:
 * In most cases, can be compiled to a single jump.
 * Can express indirect `goto` via function-pointer calls.
 * Can be used as a compile target for languages with unrestricted PTCs; the code
-  generator can use a stack in the heap to effectively implement a custom call
+  generator can use a stack in the linear memory to effectively implement a custom call
   ABI on top of signature-restricted PTCs.
 * An engine that wishes to perform aggressive optimization can fuse a graph of
   PTCs into a single function.

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -14,7 +14,7 @@ This is covered in the [tooling](Tooling.md) section.
 ## Dynamic linking
 
 [Dynamic loading](MVP.md#code-loading-and-imports) is in [the MVP](MVP.md), but
-all loaded modules have their own [separate linear memory](MVP.md#memory) and cannot share
+all loaded modules have their own [separate linear memory](MVP.md#linear-memory) and cannot share
 [function pointers](MVP.md#function-pointers). Dynamic linking will allow
 developers to share memory and function pointers between WebAssembly modules.
 

--- a/MVP.md
+++ b/MVP.md
@@ -34,9 +34,9 @@ separate docs with more precise descriptions of:
   * In a minimal shell environment, imports could be limited to builtin modules
     (implemented by the shell) and/or shell scripts.
   * The [dynamic linking](FutureFeatures.md#dynamic-linking) post-MVP feature
-    would extend the semantics to include multiple modules and thus allow heap
-    and pointer sharing. Dynamic linking would be semantically distinct from
-    importing, though.
+    would extend the semantics to include multiple modules and thus allow sharing 
+linear memory and pointers. Dynamic linking would be semantically distinct from
+    importing, however.
 * When compiling from C++, imports would be generated for unresolved `extern`
   functions and calls to those `extern` functions would call the import.
 * Host environments can define builtin modules that are implemented natively but
@@ -60,7 +60,7 @@ separate docs with more precise descriptions of:
   * module import section;
   * globals section (constants, signatures, variables);
   * code section;
-  * heap initialization section.
+  * memory initialization section.
 
 ## Code section
 
@@ -89,21 +89,21 @@ separate docs with more precise descriptions of:
 The [text format](TextFormat.md) provides readability to developers, and is
 isomorphic to the [binary format](BinaryEncoding.md).
 
-## Heap
+## Linear Memory
 
-* In the MVP, when a WebAssembly module is loaded, it creates a new heap which
+* In the MVP, when a WebAssembly module is loaded, it creates a new linear memory which
   isn't directly accessible from other modules.
 * The [dynamic linking](FutureFeatures.md#dynamic-linking) feature will be
-  necessary for two WebAssembly modules to share the same heap.
-* Modules can specify heap size and initialization data (`data`, `rodata`,
-  `bss`) in the [heap-initialization section](MVP.md#module-structure).
-* Modules can specify whether the heap is growable (via `sbrk`).
-* Modules can optionally export the heap, allowing it to be aliased by the
+  necessary for two WebAssembly modules to share the same linear memory.
+* Modules can specify memory size and initialization data (`data`, `rodata`,
+  `bss`) in the [memory-initialization section](MVP.md#module-structure).
+* Modules can specify whether memory is growable (via `sbrk`).
+* Modules can optionally export memory, allowing it to be aliased by the
   embedder, such as JavaScript:
-  * JavaScript sees the exported heap as an `ArrayBuffer`.
-  * To keep an `ArrayBuffer`'s length immutable, resizing a module's heap
+  * JavaScript sees the exported memory as an `ArrayBuffer`.
+  * To keep an `ArrayBuffer`'s length immutable, resizing a module's memory
     detaches any existent `ArrayBuffer`.
-* See the [AST Semantics heap section](AstSemantics.md#accessing-the-heap) for
+* See the [AST Semantics memory section](AstSemantics.md#accessing-the-memory) for
   more details.
  
 ## Security

--- a/MVP.md
+++ b/MVP.md
@@ -103,7 +103,7 @@ isomorphic to the [binary format](BinaryEncoding.md).
   * JavaScript sees the exported memory as an `ArrayBuffer`.
   * To keep an `ArrayBuffer`'s length immutable, resizing a module's memory
     detaches any existent `ArrayBuffer`.
-* See the [AST Semantics memory section](AstSemantics.md#accessing-the-memory) for
+* See the [AST Semantics memory section](AstSemantics.md#accessing-linear-memory) for
   more details.
  
 ## Security

--- a/PostMVP.md
+++ b/PostMVP.md
@@ -18,7 +18,7 @@ happens-before relationship, and synchronize-with edges as defined in other
 languages.
 
 Modules can have global variables that are either shared or thread-local. While
-the heap could be used for shared global variables, global variables are not
+the linear memory could be used to store shared global variables, global variables are not
 aliasable and thus allow more aggressive optimization.
 
   [synchronic]: http://wg21.link/n4195

--- a/Web.md
+++ b/Web.md
@@ -25,10 +25,10 @@ that the design, especially that of the [MVP](MVP.md), are sensible:
     resulting ES6 module (which could be implemented in JS or WebAssembly) is
     queried for the export name.
   - There is no special case for when one WebAssembly module imports another:
-    they have separate [heaps](MVP.md#heap) and pointers cannot be passed
+    they have separate [memory](MVP.md#linear-memory) and pointers cannot be passed
     between the two. Module imports encapsulate the importer and
     importee. [Dynamic linking](FutureFeatures.md#dynamic-linking) should be
-    used to share heaps and pointers across modules.
+    used to share memory and pointers across modules.
   - To synchronously call into JavaScript from C++, the C++ code would declare
     and call an undefined `extern` function and the target JavaScript function
     would be given the (mangled) name of the `extern` and put inside the


### PR DESCRIPTION
PTAL in case I missed a spot or two.

I updated uses of "heap" "the heap" and "heaps" to "linear memory" "the linear memory" "linear memories" or "memory" as dictated by context, clarity, and brevity.
