### PR TITLE
Move handling of subnormals into FutureFeatures.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -401,8 +401,6 @@ Floating point arithmetic follows the IEEE-754 standard, except that:
  - WebAssembly uses the round-to-nearest ties-to-even rounding attribute, except
    where otherwise specified. Non-default directed rounding attributes are not
    supported.
- - The strategy for gradual underflow (subnormals) is
-   [under discussion](https://github.com/WebAssembly/design/issues/148).
 
 In the future, these limitations may be lifted, enabling
 [full IEEE-754 support](FutureFeatures.md#full-ieee-754-conformance).

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -337,6 +337,14 @@ enabled only from developer tools, that would enable traps on selected floating
 point exceptions, however care should be taken, since not all floating point
 exceptions indicate bugs.
 
+## Flushing Subnormal Values to Zero
+
+Many popular CPUs have significant stalls when processing subnormal values,
+and support modes where subnormal values are flushed to zero which avoid
+these stalls. And, ARMv7 NEON has no support for subnormal values and always
+flushes them. A mode where floating point computations have subnormals flushed
+to zero in WebAssembly would address these two issues.
+
 ## Integer Overflow Detection
 
 There are two different use cases here, one where the application wishes to


### PR DESCRIPTION
With #243 (the subnormal_mode proposal) closed, this PR instead addresses #148 by moving subnormal flushing into FutureFeatures.md.

In the public discussion in #148, there is consensus for supporting subnormals by default in the MVP. And, we have abundant of data confirming that this is practical, since asm.js has subnormals enabled and does not even have any way to disable them.