### PR TITLE
Conversions have nondeterministic NaN bits too.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -486,8 +486,7 @@ Promotion and demotion of floating point values always succeed.
 Demotion of floating point values uses round-to-nearest ties-to-even rounding,
 and may overflow to infinity or negative infinity as specified by IEEE-754.
 If the operand of promotion or demotion is NaN, the sign bit and significand
-of the result are computed from an unspecified function of the implementation,
-the opcode, and the operand.
+of the result are not specified.
 
 Reinterpretations always succeed.
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,7 +31,9 @@ currently admits nondeterminism:
    nondeterministic.
  * Out of bounds heap accesses *may* want
    [some flexibility](AstSemantics.md#out-of-bounds)
- * [NaN bit patterns](AstSemantics.md#floating-point-operations)
+ * NaN bit patterns in floating point
+   [operations](AstSemantics.md#floating-point-operations) and
+   [conversions](AstSemantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions)
  * [Fixed-width SIMD may want some flexibility](PostMVP.md#fixed-width-simd)
    - In SIMD.js, floating point values may or may not have subnormals flushed to
      zero.


### PR DESCRIPTION
An earlier rule tried to limit the nondeterminism of NaN bits. This was found to be untenable and was loosened for floating point operations. This pull request does for for conversion operations as well.