### PR TITLE
Define `memmove` and `memzero` operators.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -236,6 +236,8 @@ source overlap.
 `memzero`'s operands are a destination address, and a size in bytes. It writes
 zeros to memory of the given size at the destination address.
 
+`memmove` and `memzero` return the value of their `destination` address operand.
+
 If any of the accessed bytes are beyond `memory_size`, the access is considered
 [out-of-bounds](AstSemantics.md#out-of-bounds).
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -223,6 +223,26 @@ MVP, there are [future features](FutureFeatures.md#finer-grained-control-over-me
 proposed to allow setting protection and creating mappings within the
 contiguous linear memory.
 
+### Bulk-Memory Operations
+
+  * `memmove`: bulk-copy memory
+  * `memzero`: bulk-zero memory
+
+`memmove`'s operands are a destination address, a source address, and a size
+in bytes. It copies memory of the given size from the source address to the
+destination address, correctly handling the case where the destination and
+source overlap.
+
+`memzero`'s operands are a destination address, and a size in bytes. It writes
+zeros to memory of the given size at the destination address.
+
+If any of the accessed bytes are beyond `memory_size`, the access is considered
+[out-of-bounds](AstSemantics.md#out-of-bounds).
+
+All the bulk-memory operator operands have type `int32` in the MVP; `int64`
+forms will be added along with the rest of the support for
+[>4GiB linear memory](FutureFeatures.md#heaps-bigger-than-4gib).
+
 ## Local variables
 
 Each function has a fixed, pre-declared number of local variables which occupy a single


### PR DESCRIPTION
This proposes what I sketched out in #236.

I'm quite open to discussing extensions to these operators to accept e.g. size and alignment hints (size hints may include things like known-multiples or known-ranges when the size isn't constant), but let's do so in a new issue.

Why `memzero` and not `memset`? It's simpler while still covering the main use case. On one hand, I'm already a nervous about adding what could be seen as macro-operators to WebAssembly in the first place. And on the other, the ability to paint memory regions with just a single-byte pattern is oddly restrictive. If we're going to add functionality like that, perhaps we should add forms for 32-bit and 64-bit patterns too.