### PR TITLE
Clarify, rename, and FAQ memory allocation

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -71,17 +71,18 @@ Global variables and linear memory accesses use memory types.
 
 The main storage of a WebAssembly module, called the *linear memory*, is a
 contiguous, byte-addressable range of memory spanning from offset `0` and
-extending for `memory_size` bytes. The linear memory can be considered to be a
-untyped array of bytes. The linear memory is sandboxed; it does not alias the
-execution engine's internal data structures, the execution stack, local
+extending for `memory_size` bytes which can be dynamically adjusted by
+[`resize_memory`](Modules.md#resizing). The linear memory can be considered to
+be an untyped array of bytes. The linear memory is sandboxed; it does not alias
+the execution engine's internal data structures, the execution stack, local
 variables, global variables, or other process memory. The initial state of
 linear memory is specified by the [module](Modules.md#initial-state-of-linear-memory).
 
-In the MVP, linear memory is not shared between threads of execution or
-modules: every module has its own separate linear memory. It will,
-however, be possible to share linear memory between separate modules and
-threads once [threads](PostMVP.md#threads) and 
-[dynamic linking](FutureFeatures.md#dynamic-inking) are added as features.
+In the MVP, linear memory is not shared between threads of execution. Separate
+modules can execute in separate threads but have their own linear memory and can
+only communicate through messaging, e.g. in browsers using `postMessage`. It
+will be possible to share linear memory between threads of execution when
+[threads](PostMVP.md#threads) are added.
 
 ### Linear Memory Operations
 
@@ -209,6 +210,17 @@ tradeoffs.
     * Either tooling or an explicit opt-in "debug mode" in the spec should allow
       execution of a module in a mode that threw exceptions on out-of-bounds
       access.
+
+### Resizing
+
+As stated [above](AstSemantics.md#linear-memory), linear memory can be resized
+by a `resize_memory` builtin operation. The resize delta is required to be a
+multiple of a global `page_size` constant.  Also as stated
+[above](AstSemantics.md#linear-memory), linear memory is contiguous, meaning
+there are no "holes" in the linear address space. After the MVP, there are
+[future features](FutureFeatures.md#finer-grained-control-over-memory) proposed
+to allow setting protection and creating mappings within the contiguous
+linear memory.
 
 ## Local variables
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -213,14 +213,19 @@ tradeoffs.
 
 ### Resizing
 
-As stated [above](AstSemantics.md#linear-memory), linear memory can be resized
-by a `resize_memory` builtin operation. The resize delta is required to be a
-multiple of a global `page_size` constant.  Also as stated
-[above](AstSemantics.md#linear-memory), linear memory is contiguous, meaning
-there are no "holes" in the linear address space. After the MVP, there are
-[future features](FutureFeatures.md#finer-grained-control-over-memory) proposed
-to allow setting protection and creating mappings within the contiguous
-linear memory.
+Linear memory can be resized by a `resize_memory` builtin operation. The
+`resize_memory` operation requires its operand to be a multiple of the system
+page size. To determine page size, a nullary `page_size` operation is provided.
+
+ * `resize_memory` : grow or shrink linear memory by a given delta which
+    must be a multiple of `page_size`
+ * `page_size` : nullary constant function returning page size
+
+Also as stated [above](AstSemantics.md#linear-memory), linear memory is
+contiguous, meaning there are no "holes" in the linear address space. After the
+MVP, there are [future features](FutureFeatures.md#finer-grained-control-over-memory)
+proposed to allow setting protection and creating mappings within the
+contiguous linear memory.
 
 ## Local variables
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -256,9 +256,6 @@ omission is:
   * This interleaving with unrelated allocations does not currently admit
     efficient security checks to prevent one module from corrupting data outside
     its heap (see discussion in [#285](https://github.com/WebAssembly/design/pull/285)).
-  * This interleaving would require making allocation nondeterministic.
-    Nondeterminism is something that WebAssemgly generally 
-    [tries to avoid](Nondeterminism.md) and history has clear examples of
-    memory allocator almost-determinism leading to real-world bustage
-    ([[1](https://technet.microsoft.com/en-us/magazine/ff625273.aspx)],
-    [[2](http://lxr.free-electrons.com/source/include/linux/personality.h?v=3.2#L31)]).
+  * This interleaving would require making allocation nondeterministic and
+    nondeterminism is something that WebAssemgly generally 
+    [tries to avoid](Nondeterminism.md).

--- a/FAQ.md
+++ b/FAQ.md
@@ -255,7 +255,7 @@ omission is:
   address space fragmentation). There are two problems with this:
   * This interleaving with unrelated allocations does not currently admit
     efficient security checks to prevent one module from corrupting data outside
-    its heap (see discussion in #285).
+    its heap (see discussion in [#285](https://github.com/WebAssembly/design/pull/285)).
   * This interleaving would require making allocation nondeterministic.
     Nondeterminism is something that WebAssemgly generally 
     [tries to avoid](Nondeterminism.md) and in this particular case, history

--- a/FAQ.md
+++ b/FAQ.md
@@ -258,7 +258,7 @@ omission is:
     its heap (see discussion in [#285](https://github.com/WebAssembly/design/pull/285)).
   * This interleaving would require making allocation nondeterministic.
     Nondeterminism is something that WebAssemgly generally 
-    [tries to avoid](Nondeterminism.md) and in this particular case, history
-    has clear examples of memory allocator nondeterminism leading to real-world
-    bustage ([[1](https://technet.microsoft.com/en-us/magazine/ff625273.aspx)],
+    [tries to avoid](Nondeterminism.md) and history has clear examples of
+    memory allocator almost-determinism leading to real-world bustage
+    ([[1](https://technet.microsoft.com/en-us/magazine/ff625273.aspx)],
     [[2](http://lxr.free-electrons.com/source/include/linux/personality.h?v=3.2#L31)]).

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -40,10 +40,27 @@ possible to use a non-standard ABI for specialized purposes.
 
 ## Finer-grained control over memory
 
-* `mmap` of files.
-* `madvise(MADV_DONTNEED)`.
-* Shared memory, where a physical address range is mapped to multiple physical
-  pages in a single WebAssembly module as well as across modules.
+Provide access to safe OS-provided functionality including:
+* `map_file(addr, length, Blob, file-offset)`: semantically, this operation
+   copies the specified range from `Blob` into the range `[addr, addr+length)`
+   (where `addr+length <= memory_size`) but implementations are encouraged
+   to `mmap(addr, length, MAP_FIXED | MAP_PRIVATE, fd)`
+* `dont_need(addr, length)`: semantically, this operation zeroes the given range
+   but the implementation is encouraged to `madvise(addr, length, MADV_DONTNEED)`
+* `shmem_create(length)`: create a memory object that can be simultaneously
+  shared between multiple linear memories
+* `map_shmem(addr, length, shmem, shmem-offset)`: like `map_file` except
+  `MAP_SHARED`, which isn't otherwise valid on read-only Blobs
+* `mprotect(addr, length, prot-flags)`: change protection on the range
+  `[addr, addr+length)` (where `addr+length <= memory_size`)
+
+The `addr` and `length` parameters above would be required to be multiples of
+the [`page_size`](AstSemantics.md#resizing) global constant.
+
+The above list of functionality mostly covers the set of functionality
+provided by the `mmap` OS primitive. One significant exception is that `mmap`
+can allocate noncontiguous virtual address ranges. See the
+[FAQ](FAQ.md#what-about-mmap) for rationale.
 
 ## More expressive control flow
 

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -47,6 +47,9 @@ Provide access to safe OS-provided functionality including:
    to `mmap(addr, length, MAP_FIXED | MAP_PRIVATE, fd)`
 * `dont_need(addr, length)`: semantically, this operation zeroes the given range
    but the implementation is encouraged to `madvise(addr, length, MADV_DONTNEED)`
+   (this allows applications to be good citizens and release unused physical
+   pages back to the OS, thereby reducing their RSS and avoiding OOM-killing on
+   mobile)
 * `shmem_create(length)`: create a memory object that can be simultaneously
   shared between multiple linear memories
 * `map_shmem(addr, length, shmem, shmem-offset)`: like `map_file` except

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -58,7 +58,7 @@ Provide access to safe OS-provided functionality including:
   `[addr, addr+length)` (where `addr+length <= memory_size`)
 
 The `addr` and `length` parameters above would be required to be multiples of
-the [`page_size`](AstSemantics.md#resizing) global constant.
+[`page_size`](AstSemantics.md#resizing).
 
 The above list of functionality mostly covers the set of functionality
 provided by the `mmap` OS primitive. One significant exception is that `mmap`

--- a/Modules.md
+++ b/Modules.md
@@ -108,8 +108,9 @@ to allow *explicitly* sharing linear memory between multiple modules.
 ## Initial state of linear memory
 
 A module will contain a section declaring the linear memory size (initial and
-maximum size allowed by `sbrk`) and the initial contents of memory (analogous
-to `.data`, `.rodata`, `.bss` sections in native executables).
+maximum size allowed by [`resize_memory`](AstSemantics.md#resizing) and the
+initial contents of memory (analogous to `.data`, `.rodata`, `.bss` sections in
+native executables).
 
 ## Code section
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,7 +31,10 @@ currently admits nondeterminism:
    nondeterministic.
  * Out of bounds heap accesses *may* want
    [some flexibility](AstSemantics.md#out-of-bounds)
- * The [`page_size` global constant](AstSemantics.md#resizing)
+ * The `page_size` global constant is device-dependent. The arguments to the
+   [`resize_memory`](AstSemantics.md#resizing) and other 
+   [future memory management builtins](FutureFeatures.md#finer-grained-control-over-memory)
+   are required to be multiples of `page_size`.
  * NaN bit patterns in floating point
    [operations](AstSemantics.md#floating-point-operations) and
    [conversions](AstSemantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions)

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,7 +31,7 @@ currently admits nondeterminism:
    nondeterministic.
  * Out of bounds heap accesses *may* want
    [some flexibility](AstSemantics.md#out-of-bounds)
- * The `page_size` global constant is device-dependent. The arguments to the
+ * The value returned by `page_size` is system-dependent. The arguments to the
    [`resize_memory`](AstSemantics.md#resizing) and other 
    [future memory management builtins](FutureFeatures.md#finer-grained-control-over-memory)
    are required to be multiples of `page_size`.

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,6 +31,7 @@ currently admits nondeterminism:
    nondeterministic.
  * Out of bounds heap accesses *may* want
    [some flexibility](AstSemantics.md#out-of-bounds)
+ * The [`page_size` global constant](AstSemantics.md#resizing)
  * NaN bit patterns in floating point
    [operations](AstSemantics.md#floating-point-operations) and
    [conversions](AstSemantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions)


### PR DESCRIPTION
Based on conversations in #285 which seemed to have settled down, this PR clarifies how WebAssembly could (in MVP + future features) implement most of mmap, renames sbrk to something without a connotation, and adds an FAQ that explains why no noncontiguous allocation.