### PR TITLE
Refactor MVP

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -69,18 +69,19 @@ Global variables and linear memory accesses use memory types.
 
 ## Linear Memory
 
-The main storage of a wasm module, called the *linear memory*, is a contiguous,
-byte-addressable range of memory spanning from offset `0` and extending for
-`memory_size` bytes. The linear memory can be considered to be a untyped array
-of bytes. The linear memory is sandboxed; it does not alias the execution
-engine's internal data structures, the execution stack, local variables, global
-variables, or other process memory.
+The main storage of a WebAssembly module, called the *linear memory*, is a
+contiguous, byte-addressable range of memory spanning from offset `0` and
+extending for `memory_size` bytes. The linear memory can be considered to be a
+untyped array of bytes. The linear memory is sandboxed; it does not alias the
+execution engine's internal data structures, the execution stack, local
+variables, global variables, or other process memory. The initial state of
+linear memory is specified by the [module](Modules.md#initial-state-of-linear-memory).
 
-In the MVP, linear memory is not shared between threads of execution. Separate
-modules can execute in separate threads but have their own linear memory and can
-only communicate through messaging, e.g. in browsers using `postMessage`. It
-will be possible to share linear memory between threads of execution when
-[threads](PostMVP.md#threads) are added.
+In the MVP, linear memory is not shared between threads of execution or
+modules: every module has its own separate linear memory. It will,
+however, be possible to share linear memory between separate modules and
+threads once [threads](PostMVP.md#threads) and 
+[dynamic linking](FutureFeatures.md#dynamic-inking) are added as features.
 
 ### Linear Memory Operations
 

--- a/MVP.md
+++ b/MVP.md
@@ -8,51 +8,20 @@ features which are available today in modern web browsers and which perform well
 even on mobile devices, which leads to roughly the same functionality as
 [asm.js](http://asmjs.org).
 
-This document explains the contents of the MVP at a high-level. There are also
-separate docs with more precise descriptions of:
-
- * [Modules](Modules.md)
- * [Polyfill to JavaScript](Polyfill.md);
- * [AST semantics](AstSemantics.md);
- * [Binary encoding](BinaryEncoding.md);
- * [Text format](TextFormat.md);
- * Implementation [in the browser](Web.md) and [outside the browser](NonWeb.md).
-
-**Note**: This content is still in flux and open for discussion.
-
-## Linear Memory
-
-* In the MVP, when a WebAssembly module is loaded, it creates a new linear memory which
-  isn't directly accessible from other modules.
-* The [dynamic linking](FutureFeatures.md#dynamic-linking) feature will be
-  necessary for two WebAssembly modules to share the same linear memory.
-* Modules can specify memory size and initialization data (`data`, `rodata`,
-  `bss`) in the [memory-initialization section](MVP.md#module-structure).
-* Modules can specify whether memory is growable (via `sbrk`).
-* Modules can optionally export memory, allowing it to be aliased by the
-  embedder, such as JavaScript:
-  * JavaScript sees the exported memory as an `ArrayBuffer`.
-  * To keep an `ArrayBuffer`'s length immutable, resizing a module's memory
-    detaches any existent `ArrayBuffer`.
-* See the [AST Semantics linear memory section](AstSemantics.md#linear-memory)
-  for more details.
-
-## Binary format
-
-* A [binary format](BinaryEncoding.md) provides efficiency: it reduces download
-  size and accelerates decoding, thus enabling even very large codebases to have
-  quick startup times. Towards that goal, the binary format will be natively
-  decoded by browsers.
-* The binary format has an equivalent and isomorphic
-  [text format](MVP.md#text-format).  Conversion from one format to the other is
-  both straightforward and causes no loss of information in either direction.
-
-## Text format
-
-The [text format](TextFormat.md) provides readability to developers, and is
-isomorphic to the [binary format](BinaryEncoding.md).
- 
-## Security
-
-WebAssembly MVP will be no looser from a security point-of-view than if the
-module was JavaScript or asm.js.
+The major design components of the MVP have been broken up into separate
+documents:
+* The distributable, loadable and executable unit of code in WebAssembly
+  is called a [module](Modules.md).
+* The behavior of WebAssembly code in a module is specified in terms of an
+  [AST](AstSemantics.md).
+* The WebAssembly binary format, which is designed to be natively decoded by 
+  WebAssembly implementations, is specified as a 
+  [binary serialization](BinaryEncoding.md) of a module's AST.
+* The WebAssembly text format, which is designed to be read and written when
+  using tools (e.g., assemblers, debuggers, profilers), is specified as a
+  [textual projection](TextFormat.md) of a module's AST.
+* WebAssembly is designed to be implemented both [by web browsers](Web.md)
+  and [completely different execution environments](NonWeb.md).
+* To ease the transition to WebAssembly while native support is still
+  being deployed, the WebAssembly MVP is designed to allow an effective
+  and efficient [polyfill to JavaScript](Polyfill.md).

--- a/Web.md
+++ b/Web.md
@@ -7,7 +7,9 @@ for example embedded in Web browsers (though this is
 This means integrating with the Web ecosystem, leveraging Web APIs, supporting
 the Web's security model, preserving the Web's portability, and designing in
 room for evolutionary development. Many of these goals are clearly
-reflected in WebAssembly's [high-level goals](HighLevelGoals.md).
+reflected in WebAssembly's [high-level goals](HighLevelGoals.md). In
+particular, WebAssembly MVP will be no looser from a security point of view
+than if the module was JavaScript.
 
 More concretely, the following is a list of points of contact between WebAssembly
 and the rest of the Web platform that have been considered:
@@ -15,6 +17,9 @@ and the rest of the Web platform that have been considered:
 * WebAssembly's [modules](Modules.md) allow for natural [integration with
   the ES6 module system](Modules.md#integration-with-es6-modules) and allow
   synchronous calling to and from JavaScript.
+* If allowed by the module, JavaScript can alias a loaded module's linear
+  memory via Typed Arrays. (To keep the Typed Arrays' lengths constant,
+  if linear memory is resized, any extant Typed Arrays are detached.)
 * WebAssembly's security model should depend on [CORS][] and
   [subresource integrity][] to enable distribution, especially through content
   distribution networks and to implement


### PR DESCRIPTION
After all the recent work splitting out and expanding sections of MVP.md, MVP.md is left in a pretty awkward empty state.  This PR moves a few of the remaining bits out to where they belong and annotates the list of links to all the different docs with short explanations of how they fit together to define the MVP.