### PR TITLE
Clarify the behavior of floating point operations in the presence of NaN

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -444,12 +444,12 @@ implementations of the remaining required operations.
   * `float32.floor`: floor operation
   * `float32.trunc`: round to nearest integer towards zero
   * `float32.nearestint`: round to nearest integer, ties to even
-  * `float32.eq`: compare equal
-  * `float32.ne`: compare unequal
-  * `float32.lt`: less than
-  * `float32.le`: less than or equal
-  * `float32.gt`: greater than
-  * `float32.ge`: greater than or equal
+  * `float32.eq`: compare ordered and equal
+  * `float32.ne`: compare unordered or unequal
+  * `float32.lt`: compare ordered and less than
+  * `float32.le`: compare ordered and less than or equal
+  * `float32.gt`: compare ordered and greater than
+  * `float32.ge`: compare ordered and greater than or equal
   * `float32.sqrt`: square root
   * `float32.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `float32.max`: maximum (binary operator); if either operand is NaN, returns NaN
@@ -465,12 +465,12 @@ implementations of the remaining required operations.
   * `float64.floor`: floor operation
   * `float64.trunc`: round to nearest integer towards zero
   * `float64.nearestint`: round to nearest integer, ties to even
-  * `float64.eq`: compare equal
-  * `float64.ne`: compare unequal
-  * `float64.lt`: less than
-  * `float64.le`: less than or equal
-  * `float64.gt`: greater than
-  * `float64.ge`: greater than or equal
+  * `float64.eq`: compare ordered and equal
+  * `float64.ne`: compare unordered or unequal
+  * `float64.lt`: compare ordered and less than
+  * `float64.le`: compare ordered and less than or equal
+  * `float64.gt`: compare ordered and greater than
+  * `float64.ge`: compare ordered and greater than or equal
   * `float64.sqrt`: square root
   * `float64.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `float64.max`: maximum (binary operator); if either operand is NaN, returns NaN

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -477,6 +477,9 @@ implementations of the remaining required operations.
 
 `min` and `max` operations treat `-0.0` as being effectively less than `0.0`.
 
+In floating point comparisons, the operands are *unordered* if either operand
+is NaN, and *ordered* otherwise.
+
 ## Datatype conversions, truncations, reinterpretations, promotions, and demotions
 
   * `int32.wrap[int64]`: wrap a 64-bit integer to a 32-bit integer


### PR DESCRIPTION
These could be assumed, but it's nice to make them explicit.