### PR TITLE
Add data segments to binary format

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -103,7 +103,7 @@ Yes:
 
 
 All strings are encoded as null-terminated UTF8.
-Data segments represent initialized data that is loaded directly from the binary into the linear memory when the program starts.
+Data segments represent initialized data that is loaded directly from the binary into the linear memory when the program starts (see [modules](Modules.md#initial-state-of-linear-memory)).
 
 ## Serialized AST
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -98,8 +98,12 @@ Yes:
       * Type ID
       * Count of locals
     + The serialized AST
+ * A `data` section contains
+   - A sequence of byte ranges within the binary and corresponding addresses in the linear memory
+
 
 All strings are encoded as null-terminated UTF8.
+Data segments represent initialized data that is loaded directly from the binary into the linear memory when the program starts.
 
 ## Serialized AST
 

--- a/Modules.md
+++ b/Modules.md
@@ -109,8 +109,8 @@ to allow *explicitly* sharing linear memory between multiple modules.
 
 A module will contain a section declaring the linear memory size (initial and
 maximum size allowed by [`resize_memory`](AstSemantics.md#resizing) and the
-initial contents of memory (analogous to `.data`, `.rodata`, `.bss` sections in
-native executables).
+initial contents of memory,analogous to `.data`, `.rodata`, `.bss` sections in
+native executables (see [binary encoding](BinaryEncoding.md#global-structure)
 
 ## Code section
 


### PR DESCRIPTION
Add a description of data segments, which are a way that the binary module can load initialized data into memory, similar to a .data section.