### PR TITLE
Reference IEEE 754-2008 specifically.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -413,21 +413,21 @@ The same operations are available on 64-bit integers as the those available for
 
 ## Floating point operations
 
-Floating point arithmetic follows the IEEE-754 standard, except that:
+Floating point arithmetic follows the IEEE 754-2008 standard, except that:
  - The sign bit and significand bit pattern of any NaN value returned from a
    floating point arithmetic operation other than `neg`, `abs`, and `copysign`
    are not specified. In particular, the "NaN propagation"
-   section of IEEE-754 is not required. NaNs do propagate through arithmetic
-   operations according to IEEE-754 rules, the difference here is that they do
-   so without necessarily preserving the specific bit patterns of the original
-   NaNs.
+   section of IEEE 754-2008 is not required. NaNs do propagate through
+   arithmetic operations according to IEEE-754 rules, the difference here is
+   that they do so without necessarily preserving the specific bit patterns of
+   the original NaNs.
  - WebAssembly uses "non-stop" mode, and floating point exceptions are not
    otherwise observable. In particular, neither alternate floating point
    exception handling attributes nor the non-computational operations on status
    flags are supported. There is no observable difference between quiet and
    signalling NaN. However, positive infinity, negative infinity, and NaN are
    still always produced as result values to indicate overflow, invalid, and
-   divide-by-zero conditions, as specified by IEEE-754.
+   divide-by-zero conditions, as specified by IEEE 754-2008.
  - WebAssembly uses the round-to-nearest ties-to-even rounding attribute, except
    where otherwise specified. Non-default directed rounding attributes are not
    supported.
@@ -435,9 +435,9 @@ Floating point arithmetic follows the IEEE-754 standard, except that:
    [under discussion](https://github.com/WebAssembly/design/issues/148).
 
 In the future, these limitations may be lifted, enabling
-[full IEEE-754 support](FutureFeatures.md#full-ieee-754-conformance).
+[full IEEE 754-2008 support](FutureFeatures.md#full-ieee-754-2008-conformance).
 
-Note that not all operations required by IEEE-754 are provided directly.
+Note that not all operations required by IEEE 754-2008 are provided directly.
 However, WebAssembly includes enough functionality to support reasonable library
 implementations of the remaining required operations.
 
@@ -519,7 +519,7 @@ is NaN, and *ordered* otherwise.
 Wrapping and extension of integer values always succeed.
 Promotion and demotion of floating point values always succeed.
 Demotion of floating point values uses round-to-nearest ties-to-even rounding,
-and may overflow to infinity or negative infinity as specified by IEEE-754.
+and may overflow to infinity or negative infinity as specified by IEEE 754-2008.
 If the operand of promotion or demotion is NaN, the sign bit and significand
 of the result are not specified.
 
@@ -528,6 +528,6 @@ Reinterpretations always succeed.
 Conversions from integer to floating point always succeed, and use
 round-to-nearest ties-to-even rounding.
 
-Truncation from floating point to integer where IEEE-754 would specify an
+Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operation exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) traps.

--- a/CAndC++.md
+++ b/CAndC++.md
@@ -105,7 +105,7 @@ Most implementation-defined behavior in C and C++ is dependent on the compiler
 rather than on the underlying platform. For those details that are dependent
 on the platform, on WebAssembly they follow naturally from having 8-bit bytes,
 32-bit and 64-bit two's complement integers, and
-[32-bit and 64-bit IEEE-754-style floating point support]
+[32-bit and 64-bit IEEE-754-2008-style floating point support]
 (AstSemantics.md#floating-point-operations).
 
 ## Portability of compiled code

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -231,10 +231,10 @@ use cases:
 
   * `float32.minnum`: minimum; if exactly one operand is NaN, returns the other operand
   * `float32.maxnum`: maximum; if exactly one operand is NaN, returns the other operand
-  * `float32.fma`: fused multiply-add (results always conforming to IEEE-754)
+  * `float32.fma`: fused multiply-add (results always conforming to IEEE 754-2008)
   * `float64.minnum`: minimum; if exactly one operand is NaN, returns the other operand
   * `float64.maxnum`: maximum; if exactly one operand is NaN, returns the other operand
-  * `float64.fma`: fused multiply-add (results always conforming to IEEE-754)
+  * `float64.fma`: fused multiply-add (results always conforming to IEEE 754-2008)
 
 `minnum` and `maxnum` operations would treat `-0.0` as being effectively less
 than `0.0`.
@@ -266,16 +266,17 @@ so there's nothing preventing WebAssembly applications from linking to an
 appropriate emulation library and getting similarly performant results.
 Emulation libraries would have more flexibility to offer approximation
 techniques such as double-double arithmetic. If we standardize 128-bit
-floating point in WebAssembly, it will probably be standard IEEE-754
+floating point in WebAssembly, it will probably be standard IEEE 754-2008
 quadruple precision.
 
-## Full IEEE-754 conformance
+## Full IEEE 754-2008 conformance
 
-WebAssembly floating point conforms IEEE-754 in most respects, but there are a
-few areas that are [not yet covered](AstSemantics.md#floating-point-operations).
+WebAssembly floating point conforms IEEE 754-2008 in most respects, but there
+are a few areas that are
+[not yet covered](AstSemantics.md#floating-point-operations).
 
-IEEE-754 NaN bit pattern propagation is presently permitted but not required.
-It would be possible for WebAssembly to require it in the future.
+IEEE 754-2008 NaN bit pattern propagation is presently permitted but not
+required. It would be possible for WebAssembly to require it in the future.
 
 To support exceptions and alternate rounding modes, one option is to define an
 alternate form for each of `add`, `sub`, `mul`, `div`, `sqrt`, and `fma`. These

--- a/Portability.md
+++ b/Portability.md
@@ -26,7 +26,7 @@ characteristics:
 * Support unaligned memory accesses or reliable trapping that allows software
   emulation thereof.
 * Two's complement signed integers in 32 bits and optionally 64 bits.
-* IEEE-754 32-bit and 64-bit floating point, except for
+* IEEE 754-2008 32-bit and 64-bit floating point, except for
   [a few exceptions](AstSemantics.md#floating-point-operations).
 * Little-endian byte ordering.
 * Memory regions which can be efficiently addressed with 32-bit


### PR DESCRIPTION
IEEE 754-2008 contains several useful improvements over IEEE 754-1985.
And should there be a future IEEE 754 document, we can update the
references at the time that we make any necessary semantic changes.