### PR TITLE
Move "polyfill" support from MVP to FutureFeatures

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -140,10 +140,6 @@ conflict-avoidance practices surrounding string names:
     * So, as a general rule, no magic numbers in the spec (other than the literal [magic number](https://en.wikipedia.org/wiki/Magic_number_%28programming%29)).
   * Instead, a module defines its *own* local index spaces of opcodes by providing tables *of names*. 
     * So what the spec *would* define is a set of names and their associated semantics.
-  * If the implementation encounters a name it doesn't implement, by default an error is thrown while loading.
-    * However, a name *may* include a corresponding polyfill function (identified by index 
-      into the function array) to be called if the name isn't natively implemented. (There are a lot
-      more details to figure out here.)
   * To avoid (over time) large index-space declaration sections that are largely the same
     between modules, finalized versions of standards would define named baseline index spaces
     that modules could optionally use as a starting point to further refine.

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -331,3 +331,36 @@ reason we haven't added these already is that they're not efficient for
 general-purpose use on several of today's popular hardware architectures.
 
   [handle trap specially]: FutureFeatures.md#trapping-or-non-trapping-strategies
+
+## Better feature testing support
+
+The MVP will provide a basic [feature detection query](FeatureTest.md) which can
+be used to allow an application to conditionally use features added after the MVP.
+However, the usual feature detection pattern in JS:
+```
+if (foo)
+    foo();
+else
+    alternativeToFoo();
+```
+won't work in WebAssembly since, when `foo` isn't supported, the use of `foo` will
+fail to at decode/validation time.
+
+In the MVP, applications wanting to conditionally use a new feature can employ a
+few brute-force strategies:
+* compile several different versions of a module, each assuming different
+  feature support and use feature testing to decide which one to load;
+* during [layer 1 decoding](BinaryEncoding.md), which happens in user code
+  anyway, use feature detection to translate unsupported opcodes into something
+  that validates (a call to `abort()` or a polyfill).
+
+However, with [SIMD](PostMVP.md#fixed-width-simd) and
+[other](FutureFeatures.md#additional-integer-operations)
+[proposed](FutureFeaturs.md#additional-floating-point-operations)
+[extensions](FutureFeaturs.md#floating-point-approximation-operations),
+it would be good to have a strategy that didn't require these brute
+force techniques (which have developer and load-time cost). The basic challenge
+is to allow a WebAssembly decoder to decode "through" an AST node that it knows
+nothing about. There are a number of ways to achieve this and more concrete
+experience with the realities of polyfilling is necessary to suggest the right
+design.

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -344,7 +344,7 @@ else
     alternativeToFoo();
 ```
 won't work in WebAssembly since, when `foo` isn't supported, the use of `foo` will
-fail to at decode/validation time.
+fail at decode/validation time.
 
 In the MVP, applications wanting to conditionally use a new feature can employ a
 few brute-force strategies:


### PR DESCRIPTION
One big missing part of the MVP design that we've talked about a few times in passing and only has one super-vague bullet in the design repo is "polyfilling".  The basic idea is that, even if we have [feature testing](https://github.com/WebAssembly/design/blob/master/FeatureTest.md) (as an AST node, presumably), code like
```
(if (feature-test "foo") (foo ...))
```
will fail to validate if `foo` isn't supported (how would the engine decode the `foo` node if it has no idea what a `foo` is?).  The hand-wavy answer is: well, if we're allowing modules to declare their own local opcode spaces for [backwards compatibility reasons](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#backwards-compatibility), we could also allow modules at the same time to declare enough structure about conditionally-supported AST nodes (list of immediates and operands) that they could be generically decoded (into either a fault or a module-chosen call to a function that has a matching signature).

On closer inspection, this hand-wavy strategy seems problematic.  For one thing, it only makes sense for eager expressions; things like statements and types would require different mechanisms.  In general, every polyfillable kind of AST node would require explicit support to be polyfillable.  This could add up to a lot of work which we'd be adding to the MVP with no use cases and no real tests of the design.  Sounds like a fail on usual "MVP?" litmus test.

At the same time, it seems pretty likely that normal uses of WebAssembly (at least in the MVP) will involve user-space decoding (of [generic and/or specific compression](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md) into the raw layer 0 format).  If user code is decoding wasm op-by-op *anyway*, that seems like a fine place to implement polyfilling: the user code would have complete control, freeing it to do arbitrarily sophisticated polyfiling.  After some experience with user-space layer 1, we could later standardize.

Based on these this reasoning, this PR removes the mention of polyfill support in BinaryEncoding.md and creates a new FutureFeatures.md section.