### PR TITLE
Consistent naming conventions for signedness, addendum

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -382,8 +382,8 @@ results into the result type.
   * `int32.ior`: sign-agnostic inclusive or
   * `int32.xor`: sign-agnostic exclusive or
   * `int32.shl`: sign-agnostic shift left
-  * `int32.shr`: sign-agnostic logical shift right
-  * `int32.sar`: sign-agnostic arithmetic shift right
+  * `int32.shr_u`: zero-replicating (logical) shift right
+  * `int32.shr_s`: sign-replicating (arithmetic) shift right
   * `int32.eq`: sign-agnostic compare equal
   * `int32.ne`: sign-agnostic compare unequal
   * `int32.lt_s`: signed less than
@@ -399,8 +399,8 @@ results into the result type.
   * `int32.popcnt`: sign-agnostic count number of one bits
 
 Shifts interpret their shift count operand as an unsigned value. When the shift
-count is at least the bitwidth of the shift, `shl` and `shr` produce `0`, and
-`sar` produces `0` if the value being shifted is non-negative, and `-1`
+count is at least the bitwidth of the shift, `shl` and `shr_u` produce `0`, and
+`shr_s` produces `0` if the value being shifted is non-negative, and `-1`
 otherwise.
 
 All comparison operations yield 32-bit integer results with `1` representing


### PR DESCRIPTION
This would fit nicely with the convention and is more informative.