### PR TITLE
Add feature test AST node

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -531,3 +531,12 @@ round-to-nearest ties-to-even rounding.
 Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operation exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) traps.
+
+## Feature test
+
+To support [feature testing](FeatureTest.md), an AST node would be provided:
+
+  * `has_feature`: return whether the given feature is supported, identified by string
+
+In the MVP, `has_feature` would always return false. As features were added post-MVP,
+`has_feature` would start returning true.

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -539,4 +539,6 @@ To support [feature testing](FeatureTest.md), an AST node would be provided:
   * `has_feature`: return whether the given feature is supported, identified by string
 
 In the MVP, `has_feature` would always return false. As features were added post-MVP,
-`has_feature` would start returning true.
+`has_feature` would start returning true. `has_feature` is a pure function, always
+returning the same value for the same string over the lifetime of a single
+instance and other related (as defined by the host environment) instances.

--- a/FeatureTest.md
+++ b/FeatureTest.md
@@ -4,8 +4,8 @@ Any feature not present in [the MVP](MVP.md) will have a corresponding feature
 test. This allows polyfills to elegantly emulate a feature, and allows
 developers to fallback to another implementation if they so desire.
 
-Feature tests will be available from WebAssembly itself, as well as from
-JavaScript.
+Feature tests will be available from
+[WebAssembly itself](AstSemantics.md#feature-test), as well as from JavaScript.
 
-Details
-[are still be hashed out](https://github.com/WebAssembly/design/issues/90).
+See also [better feature testing support](FutureFeatures.md#better-feature-testing-support)
+in future features.


### PR DESCRIPTION
We've discussed having a way to feature test from within wasm code (including in FeatureTest.md).  AST node makes it easy to const-fold.