### PR TITLE
Add call_import to call section

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -306,10 +306,14 @@ Direct calls to a function specify the callee by index into a function table.
 
   * `call_direct`: call function directly
 
-Calls must match the function signature
-exactly. [Imported functions](MVP.md#code-loading-and-imports) also have
-signatures and are added to the same function table and are thus also callable
-via `call_direct`.
+Calls must match the function signature exactly.
+
+Like direct calls, calls to [imports](Modules.md#imports-and-exports) specify
+the callee by index into an import table (defined by the sequence of import
+declarations in the module import section) and the call must match the declared
+signature of the import exactly.
+
+  * `call_import` : call imported function directly
 
 Indirect calls may be made to a value of function-pointer type. A 
 function-pointer value may be obtained for a given function as specified by its index


### PR DESCRIPTION
This patch tweaks the call section to match [#54](https://github.com/WebAssembly/spec/pull/54) in the spec repo.  As [explained](https://github.com/WebAssembly/spec/pull/54#issue-105841895), instead of attempting to inject imports into the function table (shared with normal function definitions), imports are given their own table called via `call_import` (instead of `call_direct`).  From what I can tell, this simplifies basically everything (spec, impl, code generator).