### PR TITLE
Rename `call_direct` to `call` to match the spec repo.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -306,7 +306,7 @@ restriction may be lifted in the future.
 
 Direct calls to a function specify the callee by index into a function table.
 
-  * `call_direct`: call function directly
+  * `call`: call function directly
 
 Calls must match the function signature exactly.
 


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/spec/issues/26 this renames `call_direct` to `call`. I personally am ok either way.