### PR TITLE
Fixes the structure of the data-section-list

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -98,7 +98,8 @@ Yes:
       * Type ID
       * Count of locals
     + The serialized AST
- * A `data` section contains
+* A `data` section contains (in this order):
+   - The generic section header
    - A sequence of byte ranges within the binary and corresponding addresses in the linear memory
 
 


### PR DESCRIPTION
The data-section-line was part of the code-section-list so I fixed that.

I added "The generic section header" to the data-section-part, because that's what written as first entry of every other section.
I added "(in this order)" to the data-section-part, because now the data-section has two entries.

You might also want to consider unifying the indentation and symbols for nested lists, but that wouldn't make any difference to the interpretation of the markdown, so I didn't change anything there.