### PR TITLE
Remove the max from the module's memory declaration.

### DIFF
--- a/Modules.md
+++ b/Modules.md
@@ -123,10 +123,12 @@ to allow *explicitly* injecting multiple modules into the same instance.
 
 ## Initial state of linear memory
 
-A module will contain a section declaring the linear memory size (initial and
-maximum size allowed by [`resize_memory`](AstSemantics.md#resizing) and the
-initial contents of memory, analogous to `.data`, `.rodata`, `.bss` sections in
-native executables (see [binary encoding](BinaryEncoding.md#global-structure)).
+A module will contain a section requesting an initial linear memory size and
+declaring the initial contents of memory, analogous to `.data`, `.rodata`,
+`.bss` sections in native executables (see
+[binary encoding](BinaryEncoding.md#global-structure)). The initial size of
+linear memory is the requested size rounded up to the nearest whole multiple of
+`page_size`.
 
 ## Code section
 


### PR DESCRIPTION
Currently, wasm modules declare a maximum linear memory size that they'll ever request via resize_memory.

However, applications that know how much memory they'll use up front can just allocate that much memory up front and avoid resizing. And applications that don't know how much memory they'll use up front won't often be able to declare a meaningful maximum.

Having a maximum value in wasm, and thus implementations that optimize based on the maximum value, will create an incentive for applications to declare a maximum even when there is no natural absolute maximum, or when they don't know what it is. This will encourage them to either declare uselessly high maximum values, or to needlessly crash on OOM when they do end up using more memory than their arbitrary maximum.

I recommend we remove the max value.

This PR also mentions that the initial memory size is rounded up to a page_size boundary.