### PR TITLE
Spell out the "literal" operators.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -350,7 +350,7 @@ values.
 
 These opcodes have an immediate operand of their associated type which is
 copied into their result value. All possible values of all types are
-supported.
+supported (including NaN values of all possible bit patterns).
 
   * `i32.literal`: produce the value of an i32 immediate
   * `i64.literal`: produce the value of an i64 immediate

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -348,8 +348,14 @@ values.
 
 ## Literals
 
-Each local type allows literal values directly in the AST. See the
-[binary encoding section](BinaryEncoding.md#constant-pool).
+These opcodes have an immediate operand of their associated type which is
+copied into their result value. All possible values of all types are
+supported.
+
+  * `i32.literal`: produce the value of an i32 immediate
+  * `i64.literal`: produce the value of an i64 immediate
+  * `f32.literal`: produce the value of an f32 immediate
+  * `f64.literal`: produce the value of an f64 immediate
 
 ## Expressions with control flow
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -346,16 +346,16 @@ function that returns multiple values will likely have to be a statement that
 specifies multiple local variables to which to assign the corresponding return
 values.
 
-## Literals
+## Constants
 
 These opcodes have an immediate operand of their associated type which is
 produced as their result value. All possible values of all types are
 supported (including NaN values of all possible bit patterns).
 
-  * `i32.literal`: produce the value of an i32 immediate
-  * `i64.literal`: produce the value of an i64 immediate
-  * `f32.literal`: produce the value of an f32 immediate
-  * `f64.literal`: produce the value of an f64 immediate
+  * `i32.const`: produce the value of an i32 immediate
+  * `i64.const`: produce the value of an i64 immediate
+  * `f32.const`: produce the value of an f32 immediate
+  * `f64.const`: produce the value of an f64 immediate
 
 ## Expressions with control flow
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -349,7 +349,7 @@ values.
 ## Literals
 
 These opcodes have an immediate operand of their associated type which is
-copied into their result value. All possible values of all types are
+produced as their result value. All possible values of all types are
 supported (including NaN values of all possible bit patterns).
 
   * `i32.literal`: produce the value of an i32 immediate


### PR DESCRIPTION
Also, remove a broken link to the binary encoding page. The binary
encoding is not yet determined, but AstSemantics.md doesn't need to
reference it right now anyway.

See also https://github.com/WebAssembly/spec/pull/88