### PR TITLE
Added else child to the if statement.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -237,7 +237,7 @@ WebAssembly offers basic structured control flow. All control flow structures
 are statements.
 
   * `block`: a fixed-length sequence of statements
-  * `if`: if statement with `then` and `else` child
+  * `if`: if statement with `then` and `else` children
   * `do_while`: do while statement, basically a loop with a conditional branch
     (back to the top of the loop)
   * `forever`: infinite loop statement (like `while (1)`), basically an

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -237,7 +237,7 @@ WebAssembly offers basic structured control flow. All control flow structures
 are statements.
 
   * `block`: a fixed-length sequence of statements
-  * `if`: if statement
+  * `if`: if statement with `then` and `else` child
   * `do_while`: do while statement, basically a loop with a conditional branch
     (back to the top of the loop)
   * `forever`: infinite loop statement (like `while (1)`), basically an


### PR DESCRIPTION
Without an else branch we would need a temp local for writing normal if/else statements. If someone just wants an normal if statement he/she can just use a empty block as an else.

Other suggestion if changing `if` is not up to debate: Add an `ifelse` and keep `if` the way it is.