### PR TITLE
Added order of evaluation

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -179,6 +179,9 @@ Thus, it is recommend that WebAssembly producers align frequently-used data to
 permit the use of natural alignment access, and use loads and stores with the
 greatest alignment values practical, while always avoiding misaligned accesses.
 
+### Order of evaluation
+
+All operands of arithmetic operations are evaluated left-to-right.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,7 +181,11 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-Operand evaluation order is deterministic. All nodes other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
+Operand evaluation order is deterministic. 
+All nodes other than control flow constructs need to evaluate their child nodes in the order they appear in the serialized AST.
+
+For example, this s-expression presentation of a i32.add node `(i32.add (i32.const 2) (get_local $x))`
+would first evaluate the `(i32.const 2)` node and afterwards the `(get_local $x)` node.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,7 +181,7 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-All operands of arithmetic operations are evaluated left-to-right.
+All operands of arithmetic operations and the arguments of function calls are evaluated left-to-right.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,7 +181,7 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-All operands of arithmetic operations and the arguments of function calls are evaluated left-to-right.
+All statements other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,7 +181,7 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-All statements other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
+Operand evaluation order is deterministic. All statements other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -183,10 +183,16 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 The evaluation order of child nodes is deterministic.
 
-All nodes other than control flow constructs need to evaluate their child nodes in the order they appear in the serialized AST.
+All nodes other than control flow constructs need to evaluate their child nodes
+in the order they appear in the serialized AST.
 
-For example, the s-expression presentation of the `i32.add` node `(i32.add (set_local $x (i32.const 1)) (set_local $x (i32.const 2)))`
-would first evaluate the child node  `(set_local $x (i32.const 1))` and afterwards the child node `(set_local $x (i32.const 2))`. The value of the local variable $x will be `2` after the `i32.add` node is fully evaluated.
+For example, the s-expression presentation of the `i32.add` node
+`(i32.add (set_local $x (i32.const 1)) (set_local $x (i32.const 2)))`
+would first evaluate the child node  `(set_local $x (i32.const 1))` and
+afterwards the child node `(set_local $x (i32.const 2))`.
+
+The value of the local variable $x will be `2` after the `i32.add` node is fully
+evaluated.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,11 +181,12 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-Operand evaluation order is deterministic. 
+The evaluation order of child nodes is deterministic.
+
 All nodes other than control flow constructs need to evaluate their child nodes in the order they appear in the serialized AST.
 
-For example, this s-expression presentation of a i32.add node `(i32.add (i32.const 2) (get_local $x))`
-would first evaluate the `(i32.const 2)` node and afterwards the `(get_local $x)` node.
+For example, the s-expression presentation of the `i32.add` node `(i32.add (set_local $x (i32.const 1)) (set_local $x (i32.const 2)))`
+would first evaluate the child node  `(set_local $x (i32.const 1))` and afterwards the child node `(set_local $x (i32.const 2))`. The value of the local variable $x will be `2` after the `i32.add` node is fully evaluated.
 
 ### Out of Bounds
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -181,7 +181,7 @@ greatest alignment values practical, while always avoiding misaligned accesses.
 
 ### Order of evaluation
 
-Operand evaluation order is deterministic. All statements other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
+Operand evaluation order is deterministic. All nodes other than control flow constructs need to evaluate their child nodes in the order they appear in the AST.
 
 ### Out of Bounds
 


### PR DESCRIPTION
Added order of evaluation notice for arithmetic operations. All other operations are to my knowledge either unary or have an obvious ordering (e.g. `if`, `do_while`).

Also see issue #399 . 