### PR TITLE
Update references to out-of-bounds behavior for recent changes to AstSemantics.md

### DIFF
--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -27,8 +27,6 @@ currently admits nondeterminism:
    shared memory, nondeterminism will be visible through the global sequence of
    API calls. With shared memory, the result of load operations is
    nondeterministic.
- * Out of bounds heap accesses *may* want
-   [some flexibility](AstSemantics.md#out-of-bounds)
  * The value returned by `page_size` is system-dependent. The arguments to the
    [`grow_memory`](AstSemantics.md#resizing) and other 
    [future memory management builtins](FutureFeatures.md#finer-grained-control-over-memory)

--- a/Polyfill.md
+++ b/Polyfill.md
@@ -56,8 +56,7 @@ Some divergences that we've identified as potentially desirable:
   general; that information also guarantees that the polyfill is both correct
   and fast.
 * **[Out of bounds heap access](AstSemantics.md#out-of-bounds)**: Regardless of
-  semantics chosen for out of bounds access in WebAssembly, an asm.js polyfill
-  will follow standard asm.js behavior:
+  WebAssembly behavior, an asm.js polyfill will follow standard asm.js behavior:
   - Out of bound stores are ignored (treated as no-op);
   - Out of bound loads return zero for integer loads or NaN for floating point.
 * **[32-bit integer operations](AstSemantics.md#32-bit-integer-operations)**:


### PR DESCRIPTION
As of 2781f71e5871176c276ed34fe641fef71d07a281, out of bounds accesses just trap, so update a few other places that discuss out of bounds behavior accordingly.