### PR TITLE
Update various references to "builtin" operations.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -316,10 +316,11 @@ it, but fast-math flags are not believed to be important enough:
 
 The [`mmap`](http://pubs.opengroup.org/onlinepubs/009695399/functions/mmap.html)
 syscall has many useful features. While these are all packed into one overloaded
-syscall in POSIX, WebAssembly unpacks this functionality into multiple builtins:
+syscall in POSIX, WebAssembly unpacks this functionality into multiple
+operations:
 
 * the MVP starts with the ability to grow linear memory via a
-  [`grow_memory`](AstSemantics.md#resizing) builtin operation;
+  [`grow_memory`](AstSemantics.md#resizing) operation;
 * proposed
   [future features](FutureFeatures.md#finer-grained-control-over-memory) would
   allow the application to change the protection and mappings for pages in the

--- a/NonWeb.md
+++ b/NonWeb.md
@@ -17,11 +17,12 @@ Non-Web environments may include JavaScript VMs (e.g. node.js), however
 WebAssembly is also being designed to be capable of being executed without a
 JavaScript VM present.
 
-The WebAssembly spec will not try to define any large portable libc-like
+The WebAssembly spec itself will not try to define any large portable libc-like
 library. However, certain features that are core to WebAssembly semantics that
-are found in native libc *would* be part of the core WebAssembly spec as either
-primitive opcodes or a function exported by a
-[builtin module](Modules.md#imports-and-exports) (e.g., `sbrk`, `dlopen`).
+are simimilar to functions found in native libc *would* be part of the core
+WebAssembly spec as primitive opcodes (e.g., the `grow_memory` operation, which
+is similar to the `sbrk` function on many systems, and in the future, operations
+similar to `dlopen`).
 
 Where there is overlap between the Web and popular non-Web environments,
 shared specs could be proposed, but these would be separate from the WebAssembly

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,7 +31,7 @@ currently admits nondeterminism:
    [some flexibility](AstSemantics.md#out-of-bounds)
  * The value returned by `page_size` is system-dependent. The arguments to the
    [`grow_memory`](AstSemantics.md#resizing) and other 
-   [future memory management builtins](FutureFeatures.md#finer-grained-control-over-memory)
+   [future memory management operations](FutureFeatures.md#finer-grained-control-over-memory)
    are required to be multiples of `page_size`.
  * NaN bit patterns in floating point
    [operations](AstSemantics.md#floating-point-operations) and


### PR DESCRIPTION
This updates a few places in the text that referred to "builtin" operations that are more accurately described as plain operations, as discussed in #362 and specifically pointed out [here](https://github.com/WebAssembly/design/issues/362#issuecomment-147327594).