### PR TITLE
Clarified that implicit return is allowed

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -325,6 +325,10 @@ function that returns multiple values will likely have to be a statement that
 specifies multiple local variables to which to assign the corresponding return
 values.
 
+If a function with a non-void return type finishes evaluating and no `return`
+was issued during the evaluation, the value of the function node is
+returned.
+
 ## Constants
 
 These opcodes have an immediate operand of their associated type which is


### PR DESCRIPTION
Current spec doesn't specify what happens in non-void functions without any return.

ml-proto is already doing it as described in the paragraph: https://github.com/WebAssembly/spec/blob/master/ml-proto/test/f32.wast#L2