### PR TITLE
Fixed formatting in floating point list

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -447,8 +447,9 @@ implementations of the remaining required operations.
   * `f32.sqrt`: square root
   * `f32.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `f32.max`: maximum (binary operator); if either operand is NaN, returns NaN
-<br>
-<br>
+
+64-bit floating point operations are as follows:
+
   * `f64.add`: addition
   * `f64.sub`: subtraction
   * `f64.mul`: multiplication

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -447,7 +447,7 @@ implementations of the remaining required operations.
   * `f32.sqrt`: square root
   * `f32.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `f32.max`: maximum (binary operator); if either operand is NaN, returns NaN
-
+<br>
   * `f64.add`: addition
   * `f64.sub`: subtraction
   * `f64.mul`: multiplication

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -448,6 +448,7 @@ implementations of the remaining required operations.
   * `f32.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `f32.max`: maximum (binary operator); if either operand is NaN, returns NaN
 <br>
+<br>
   * `f64.add`: addition
   * `f64.sub`: subtraction
   * `f64.mul`: multiplication


### PR DESCRIPTION
Two new lines create a paragraph in the list which creates a funny looking spacing around the `f32.max` and `f64.add` item. This should fix it.