### PR TITLE
Make C/C++ long double be float128

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -22,6 +22,17 @@ has an LP64 data model, meaning that `long` and pointer types will be
 added in the future to support
 [64-bit address spaces](FutureFeatures.md#linear-memory-bigger-than-4-gib).
 
+`float` and `double` are the IEEE 754-2008 single- and double-precision types,
+which are native in WebAssembly. `long double` is the IEEE 754-2008
+quad-precision type, which is a software-emulated type. WebAssembly does
+not have a builtin quad-precision type. Quad-precision is not part of
+the WebAssembly platform itself. There are no quad-precision operators
+built into WebAssembly. The long double type here is software-emulated
+in library code linked into WebAssembly applications that need it.
+
+For performance and compatibility with other platforms, `float` and
+`double` are recommended for most uses.
+
 ### Language Support
 
 C and C++ language conformance is largely determined by individual compiler


### PR DESCRIPTION
This PR does not propose to add float128 to WebAssembly itself.

This is just about deciding what "long double" in C/C++ should be, and making it a software-emulated type, where the software is a library linked into C/C++ applications that need it, is one possible approach. Note that commonly used libraries such as [glibc](http://www.gnu.org/software/libc/), [musl](http://www.musl-libc.org/), [libgcc](https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html#Soft-float-library-routines), and [compiler-rt](http://compiler-rt.llvm.org/) all have existing software emulation code for float128, so this won't require a lot of implementation work; it'll mostly just be configuring everything properly.

The case for making C/C++ long double something other than 64-bit is:
  - There are use cases for greater-precision floating point types, and
    "long double" is a friendlier way to satisfy those use cases than
    extensions like "__float128" since "long double" has the benefit of libm
    and printf API support.
  - Long double is a lost cause in terms of portable functionality anyway.
    64-bit, 80-bit, and 128-bit long double types are in use in popular
    platforms, so people who want portable results aren't using it.
  - It's also mostly a lost cause in terms of portable performance, as it's
    already significantly slower than double on several widely popular
    platforms, so people who want portable performance already have
    motivation to avoid it.
    
The rationale for picking quad-precision over double-double is that even though double-double can be significantly faster, it has surprising numeric properties which make it undesirable to impose on unsuspecting code.

Also note that the official [ARM64 ABI](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0CB4QFjAAahUKEwjvtO2NkMPIAhUWwGMKHeIRCzE&url=http%3A%2F%2Finfocenter.arm.com%2Fhelp%2Ftopic%2Fcom.arm.doc.ihi0055b%2FIHI0055B_aapcs64.pdf&usg=AFQjCNGLmLB2Cqb0fHkmso17Axd755IpHg) makes long double be a float128 type.

Objections may include:
 - This could increase code size, even for people who don't need the functionality. This is presently the case for the musl printf code, for example, which casts narrower types to long double. However, there would be advantages to fixing this code to use a different approach anyway, so assuming we do that, and that other such situations can also be addressed in similar ways, this wouldn't be a problem in the long term.
 - This adds some complexity for people writing compilers and tools that want to interface with WebAssembly code. I don't think it's a lot of complexity though.
 - This makes code that carelessly does use long double slower. The long-term answer there is to fix code that only needs double precision to use double precision directly.