### PR TITLE
Flexible control-flow operators.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -267,7 +267,7 @@ All control flow structures, except `case`, are statements.
 References to labels must occur within an *enclosing construct* that defined
 the label. This means that references to an AST node's label can only happen
 within descendents of the node in the tree. For example, references to a
-`block`'s label can only happen from within the `block`'s body. In practice,
+`block`'s label can only occur within the `block`'s body. In practice,
 one can arrange `block`s to put labels wherever one wants to jump to, except
 for one restriction: one can't jump into the middle of a loop from outside
 it. This restriction ensures the well-structured property discussed below.

--- a/Rationale.md
+++ b/Rationale.md
@@ -114,7 +114,19 @@ developer.
 
 ## Control Flow
 
-See [#299](https://github.com/WebAssembly/design/pull/299).
+Structured control flow provides simple and size-efficient binary encoding and
+compilation. Any control flow—even irreducible—can be transformed into structured
+control flow with the
+[Relooper](https://github.com/kripken/emscripten/raw/master/docs/paper.pdf)
+[algorithm](http://dl.acm.org/citation.cfm?id=2048224&CFID=670868333&CFTOKEN=46181900),
+with guaranteed low code size overhead, and typically minimal throughput
+overhead (except for pathological cases of irreducible control
+flow). Alternative approaches can generate reducible control flow via node
+splitting, which can reduce throughput overhead, at the cost of increasing
+code size (potentially very significantly in pathological cases).
+Also,
+[more expressive control flow constructs](FutureFeatures.md#more-expressive-control-flow)
+may be added in the future.
 
 
 ## Locals


### PR DESCRIPTION
This introduces `br`, `br_if`, and so on, while also preserving the
high-level `if` and `if_else` operators. It also converts `switch` into
`tableswitch` and generalizes it to support labels in enclosing scopes.