### PR TITLE
Change linear memory max to be a hint

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -71,7 +71,7 @@ be an untyped array of bytes, and it is unspecified how embedders map this array
 into their process' own [virtual memory][]. The linear memory is sandboxed; it
 does not alias the execution engine's internal data structures, the execution
 stack, local variables, or other process memory. The initial state of linear
-memory is specified by the [module](Modules.md#initial-state-of-linear-memory).
+memory is specified by the [module](Modules.md#linear-memory-section).
 
   [virtual memory]: https://en.wikipedia.org/wiki/Virtual_memory
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -103,8 +103,9 @@ Yes:
    - A sequence of byte ranges within the binary and corresponding addresses in the linear memory
 
 
-All strings are encoded as null-terminated UTF8.
-Data segments represent initialized data that is loaded directly from the binary into the linear memory when the program starts (see [modules](Modules.md#initial-state-of-linear-memory)).
+All strings are encoded as null-terminated UTF8. Data segments represent
+initialized data that is loaded directly from the binary into the linear memory
+when the program starts (see [modules](Modules.md#linear-memory-section)).
 
 ## Serialized AST
 

--- a/Modules.md
+++ b/Modules.md
@@ -8,7 +8,7 @@ is determined by the module it was loaded from.
 
 A module contains:
 * a set of [imports and exports](Modules.md#imports-and-exports);
-* a section defining the [initial state of linear memory](Modules.md#initial-state-of-linear-memory);
+* a section defining [linear memory](Modules.md#linear-memory-section);
 * a section containing [code](Modules.md#code-section);
 * after the MVP, sections containing [debugging/symbol information](Tooling.md) or
   a reference to separate files containing them; and
@@ -122,12 +122,22 @@ shared `malloc` and coordinated global address ranges). Instead, the
 [dynamic linking future feature](DynamicLinking.md) is intended
 to allow *explicitly* injecting multiple modules into the same instance.
 
-## Initial state of linear memory
+## Linear memory section
 
-A module will contain a section declaring the linear memory size (initial and
-maximum size allowed by [`grow_memory`](AstSemantics.md#resizing) and the
-initial contents of memory, analogous to `.data`, `.rodata`, `.bss` sections in
-native executables (see [binary encoding](BinaryEncoding.md#global-structure)).
+A module may contain an optional section declaring the use of linear memory
+by the module. If the section is absent, the linear memory operators
+`load`, `store`, `memory_size`, and `grow_memory` may not be used in the module.
+
+The linear memory section declares the initial [memory size](AstSemantics.md#linear-memory)
+(which may be subsequently increased by [`grow_memory`](AstSemantics.md#resizing)).
+
+The initial contents of linear memory are zero by default. However, the memory
+section contains a possibly-empty array of *segments* (analogous to `.data`)
+which can specify the initial contents of fixed ranges of memory.
+
+The linear memory section may also contain an optional hint declaring the maximum
+heap usage. This hint is not semantically visible but can help a WebAssembly engine
+to optimize `grow_memory`.
 
 ## Code section
 

--- a/Modules.md
+++ b/Modules.md
@@ -133,11 +133,12 @@ The linear memory section declares the initial [memory size](AstSemantics.md#lin
 
 The initial contents of linear memory are zero by default. However, the memory
 section contains a possibly-empty array of *segments* (analogous to `.data`)
-which can specify the initial contents of fixed ranges of memory.
+which can specify the initial contents of fixed `(offset, length)` ranges of
+memory.
 
-The linear memory section may also contain an optional hint declaring the maximum
-heap usage. This hint is not semantically visible but can help a WebAssembly engine
-to optimize `grow_memory`.
+The linear memory section may also contain an optional hint declaring the expected
+maximum heap usage. This hint is not semantically visible but can help a
+WebAssembly engine to optimize `grow_memory`.
 
 ## Code section
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -112,6 +112,11 @@ to communicate their own implementation details in a useful manner to the
 developer.
 
 
+## Linear memory disabled if no linear memory section
+
+See [#107](https://github.com/WebAssembly/spec/pull/107).
+
+
 ## Control Flow
 
 See [#299](https://github.com/WebAssembly/design/pull/299).


### PR DESCRIPTION
(Following up on #370.)  Got to discuss this issue a bit more with @titzer and @dschuff.  We found two root use cases:
* giving the VM a hint so that it can preallocate space to avoid realloc'ing in `grow_memory`
* telling the VM there will never be growth (via initial=max) so it can optimize based on this knowledge

For the former use case, `max` actually isn't a great hint because it must be set quite conservatively (greater than the peak usage of the app for all possible executions).  So a hint that could be non-fatally exceeded would be more accurate and thus useful to the VM.  Also, a hint doesn't punish the dev/user for failing to anticipate a corner case where memory peaks higher than what the dev observed during testing when all the dev wanted was a little perf boost.  Lastly, if the engine supports resizing, then it can be more aggressive about pre-allocating the max size since, if virtual address space gets tight in the process, the engine can release the extra preallcoated space and fall back on realloc.

For the latter use case, what's needed is just an optional flag `no_resize` (which constrains both the main module and all future dynamically-linked modules).  After some impl discussion, there doesn't appear to be any major known needs in the current anticipated engine impls so it seems best to leave it out of the MVP until there is a demonstrated need.  In a totally separate discussion about how JS can alias wasm linear memory, we found a pretty significant use case for `no_resize` though: with threads, wasm linear memory could move at any time so we can't simply hand out a SharedArrayBuffer to JS (and the rest of the browser).  Rather, we would need to restrict aliasing to only when `no_resize` is set and provide a threadsafe, but less efficient, copy in/out API fallback.