### PR TITLE
Move low-memory faulting to FutureFeatures.md

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -131,11 +131,7 @@ interpreted as an unsigned byte index.
 Linear memory operators access the bytes starting at the effective address and
 extend for the number of bytes implied by the storage size. If any of the
 accessed bytes are beyond `memory_size`, the access is considered
-*out-of-bounds*. A module may optionally define that out-of-bounds includes
-small effective addresses close to `0`
-(see [discussion](https://github.com/WebAssembly/design/issues/204)).
-The semantics of out-of-bounds accesses are discussed
-[below](AstSemantics.md#out-of-bounds).
+*out-of-bounds*.
 
 The use of infinite-precision in the effective address computation means that
 the addition of the offset to the address never causes wrapping, so if the

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -39,6 +39,13 @@ Provide access to safe OS-provided functionality including:
 The `addr` and `length` parameters above would be required to be multiples of
 [`page_size`](AstSemantics.md#resizing).
 
+The `mprotect` operator would require hardware memory protection to execute
+efficiently and thus may be added as an "optional" feature (requiring a
+[feature test](FeatureTest.md) to use). To support efficient execution even when
+no hardware memory protection is available, a restricted form of `mprotect`
+could be added which is declared statically and only protects low memory
+(providing the expected fault-on-low-memory behavior of native C/C++ apps).
+
 The above list of functionality mostly covers the set of functionality
 provided by the `mmap` OS primitive. One significant exception is that `mmap`
 can allocate noncontiguous virtual address ranges. See the


### PR DESCRIPTION
There was general consensus in #204 and again in recent discussions to have low-memory faulting be a post-MVP future feature since it fits in well with the other [fine-grained memory control](https://github.com/WebAssembly/design/blob/master/FutureFeatures.md#finer-grained-control-over-memory) features.  This PR moves mention of low-memory faulting from AstSemantics.md (which is the MVP) to FutureFeatures.md and expands on the option mentioned in #204 of treating low-memory separate from `mprotect` (since it allows more efficient impl when hw memory protection isn't available).