### PR TITLE
Full IEEE 754-2008 compliant NaN bit pattern propagation.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -403,13 +403,9 @@ The same operators are available on 64-bit integers as the those available for
 ## Floating point operators
 
 Floating point arithmetic follows the IEEE 754-2008 standard, except that:
- - The sign bit and significand bit pattern of any NaN value returned from a
-   floating point arithmetic operator other than `neg`, `abs`, and `copysign`
-   are not specified. In particular, the "NaN propagation"
-   section of IEEE 754-2008 is not required. NaNs do propagate through
-   arithmetic operators according to IEEE 754-2008 rules, the difference here
-   is that they do so without necessarily preserving the specific bit patterns
-   of the original NaNs.
+ - The sign bit and fraction field of any NaN value returned from a floating
+   point arithmetic operator are deterministic under more circumstances than
+   required by IEEE 754-2008.
  - WebAssembly uses "non-stop" mode, and floating point exceptions are not
    otherwise observable. In particular, neither alternate floating point
    exception handling attributes nor the non-computational operators on status
@@ -427,6 +423,23 @@ In the future, these limitations may be lifted, enabling
 Note that not all operators required by IEEE 754-2008 are provided directly.
 However, WebAssembly includes enough functionality to support reasonable library
 implementations of the remaining required operators.
+
+When the result of any arithemtic operation other than `neg`, `abs`, or
+`copysign` is a NaN, the sign bit and the fraction field (which does not include
+the implicit leading digit of the significand) of the NaN are computed as
+follows:
+
+ - If the operation has exactly one NaN operand, the result NaN has the same
+   bits as that operand, except that the most significant bit of the
+   fraction field is 1.
+ - If the operation has multiple NaN input values, the result value is computed
+   as if one of the operands, selected nondeterministically, is the only NaN
+   operand (as described in the previous rule).
+ - If the operation has no NaN input values, the result value has a sign bit of
+   0 and a fraction field with 1 in the most significant bit and 0 in the
+   remaining bits.
+
+32-bit floating point operations are as follows:
 
   * `f32.add`: addition
   * `f32.sub`: subtraction
@@ -509,8 +522,16 @@ Wrapping and extension of integer values always succeed.
 Promotion and demotion of floating point values always succeed.
 Demotion of floating point values uses round-to-nearest ties-to-even rounding,
 and may overflow to infinity or negative infinity as specified by IEEE 754-2008.
-If the operand of promotion or demotion is NaN, the sign bit and significand
-of the result are not specified.
+
+If the operand of promotion is a NaN, the result is a NaN with the sign bit
+of the operand and a fraction field consisting of 1 in the most significant bit,
+followed by all but the most significant bits of the fraction field of the
+operand, followed by all 0s.
+
+If the operand of demotion is a NaN, the result is a NaN with the sign bit
+of the operand and a fraction field consisting of 1 in the most significant bit,
+followed by as many of all but the most significant bit of the fraction field of
+the operand as fit.
 
 Reinterpretations always succeed.
 

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -309,9 +309,6 @@ WebAssembly floating point conforms IEEE 754-2008 in most respects, but there
 are a few areas that are
 [not yet covered](AstSemantics.md#floating-point-operators).
 
-IEEE 754-2008 NaN bit pattern propagation is presently permitted but not
-required. It would be possible for WebAssembly to require it in the future.
-
 To support exceptions and alternate rounding modes, one option is to define an
 alternate form for each of `add`, `sub`, `mul`, `div`, `sqrt`, and `fma`. These
 alternate forms would have extra operands for rounding mode, masked traps, and
@@ -326,7 +323,9 @@ in the spec itself. Implementations are welcome (and encouraged) to support
 non-standard execution modes, enabled only from developer tools, such as modes
 with alternate rounding, or evaluation of floating point expressions at greater
 precision, to support [techniques for detecting numerical instability]
-(https://www.cs.berkeley.edu/~wkahan/Mindless.pdf).
+(https://www.cs.berkeley.edu/~wkahan/Mindless.pdf), or modes using alternate
+NaN bitpattern rules, to carry diagnostic information and help developers track
+down the sources of NaNs.
 
 To help developers find the sources of floating point exceptions,
 implementations may wish to provide a mode where NaN values are produced with

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -30,9 +30,10 @@ currently admits nondeterminism:
    shared memory, nondeterminism will be visible through the global sequence of
    API calls. With shared memory, the result of load operators is
    nondeterministic.
- * NaN bit patterns in floating point
-   [operators](AstSemantics.md#floating-point-operators) and
-   [conversions](AstSemantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions)
+ * Except when otherwise specified, when an arithmetic operator with multiple
+   floating point operand types and a floating point result type recieves
+   multiple NaN input values with differing bit patterns, it is nondeterminsitic
+   which bit pattern is used as the basis for the result.
  * [Fixed-width SIMD may want some flexibility](PostMVP.md#fixed-width-simd)
    - In SIMD.js, floating point values may or may not have subnormals flushed to
      zero.

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -31,7 +31,7 @@ currently admits nondeterminism:
    API calls. With shared memory, the result of load operators is
    nondeterministic.
  * Except when otherwise specified, when an arithmetic operator with multiple
-   floating point operand types and a floating point result type recieves
+   floating point operand types and a floating point result type receives
    multiple NaN input values with differing bit patterns, it is nondeterminsitic
    which bit pattern is used as the basis for the result.
  * [Fixed-width SIMD may want some flexibility](PostMVP.md#fixed-width-simd)

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -33,7 +33,8 @@ currently admits nondeterminism:
  * Except when otherwise specified, when an arithmetic operator with multiple
    floating point operand types and a floating point result type receives
    multiple NaN input values with differing bit patterns, it is nondeterminsitic
-   which bit pattern is used as the basis for the result.
+   which bit pattern is used as the basis for the result (as it is in
+   IEEE 754-2008).
  * [Fixed-width SIMD may want some flexibility](PostMVP.md#fixed-width-simd)
    - In SIMD.js, floating point values may or may not have subnormals flushed to
      zero.

--- a/Polyfill.md
+++ b/Polyfill.md
@@ -70,6 +70,10 @@ Some divergences that we've identified as potentially desirable:
   standard behavior:
   - Return zero when conversion from floating point to integer fails;
   - Optionally canonicalize NaN values.
+* **[NaN bit-pattern propagation](AstSemantics.md#floating-point-operators)**:
+  Regardless of WebAssembly behavior, an asm.js polyfill will follow its
+  standard behavior:
+  - Optionally canonicalize NaN values.
 
 ## Polyfill Evolution
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -284,6 +284,13 @@ desirable property of making it easier to port interpreters to WebAssembly that
 use NaN-boxing, because they can rely on the property that if an arithmetic
 operation has no non-canonical NaNs as input, its output is also canonical.
 
+The specific bit-pattern rules are modeled after what numerous popular
+hardware architectures do. Note that IEEE 754-1985 had looser rules for NaN
+bit pattern encodings than IEEE 754-2008, and some hardware architectures,
+notably MIPS, historically behaved differently than other architectures.
+However, since the publication of IEEE 754-2008, MIPS has added a configuration
+mode (NAN2008) which enables support for the new rules.
+
 
 ## Motivating Scenarios for Feature Testing
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -275,6 +275,16 @@ architectures there may be a need to revisit some of the decisions:
   which that language doesn't care about, but which another language may want.
 
 
+## NaN bit pattern propagation
+
+In general, WebAssembly's floating point operations propagate NaN bit patterns.
+When an operation has a NaN operand, it returns a NaN result with the same bit
+pattern. This is done in accordance with IEEE 754-2008, and it also has the
+desirable property of making it easier to port interpreters to WebAssembly that
+use NaN-boxing, because they can rely on the property that if an arithmetic
+operation has no non-canonical NaNs as input, its output is also canonical.
+
+
 ## Motivating Scenarios for Feature Testing
 
 1. [Post-MVP](PostMVP.md),


### PR DESCRIPTION
The current NaN propagation rules leave NaN payloads nondeterministic after most operators, which makes them inefficient to use for NaN-boxing in language interpreters running on top of WebAssembly.

This PR addresses this use case by changing WebAssembly to use full IEEE 754-2008 conforming NaN bit propagation to WebAssembly. This eliminates almost all of the non-determinism, though a little bit remains (binary operators that receive multiple NaN operands have to pick one to form their return value -- IEEE 754-2008 itself has this nondeterminism too). It also goes beyond IEEE 754-2008 in that it specifies the bit-pattern of a NaN generated from an invalid condition.

The algorithms described here for computing NaN result values admittadly look somewhat elaborate, but this is what x86, ARM (in its default mode, though not in "Default NaN" mode), Power, and MIPS (in IEEE 754-2008 mode, though not in legacy mode) all do. A possible exception is conversions on MIPS, where the documentation I have is vague -- it suggests that the bits are preserved in a conversion, but it doesn't seem to say exactly how -- however in the worst case a MIPS implementation could check for NaN after a conversion and handle it explicitly in a cold path if necessary.

This patch leaves the `min` and `max` operators in place, even though they'll be harder to implement on x86 under the new NaN rules, since they'll remain easy on ARM and Power, and are desirable instructions to have in an ISA in general.