### PR TITLE
Move rotate instructions from FutureFeatures to AstSemantics.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -369,6 +369,8 @@ results into the result type.
   * `i32.shl`: sign-agnostic shift left
   * `i32.shr_u`: zero-replicating (logical) shift right
   * `i32.shr_s`: sign-replicating (arithmetic) shift right
+  * `i32.rotl`: sign-agnostic rotate left
+  * `i32.rotr`: sign-agnostic rotate right
   * `i32.eq`: sign-agnostic compare equal
   * `i32.ne`: sign-agnostic compare unequal
   * `i32.lt_s`: signed less than
@@ -387,6 +389,11 @@ Shifts counts are wrapped to be less than the log-base-2 of the number of bits
 in the value to be shifted, as an unsigned quantity. For example, in a 32-bit
 shift, only the least 5 significant bits of the count affect the result. In a
 64-bit shift, only the least 6 significant bits of the count affect the result.
+
+Rotate counts are treated as unsigned.  A count value greater than or equal
+to the number of bits in the value to be rotated yields the same result as
+if the count was wrapped to its least significant N bits, where N is 5 for
+an i32 value or 6 for an i64 value.
 
 All comparison operators yield 32-bit integer results with `1` representing
 `true` and `0` representing `false`.

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -241,8 +241,6 @@ use cases:
 * The following operators can be built from other operators already present,
   however in doing so they read at least one non-constant input multiple times,
   breaking single-use expression tree formation.
-  * `i32.rotr`: sign-agnostic bitwise rotate right
-  * `i32.rotl`: sign-agnostic bitwise rotate left
   * `i32.min_s`: signed minimum
   * `i32.max_s`: signed maximum
   * `i32.min_u`: unsigned minimum


### PR DESCRIPTION
This is the follow up to design issue #422, adding rotate instructions to the MVP (but not bswap at this time).

You'll notice I added a description of wrapping behavior on the rotate count.
I don't think this is strictly needed as rotates, unlike shifts, have well defined
and consistent mathematical behavior with large counts.  And arguably even
negative counts would "just work" if treated as a rotate in the opposite direction.

For simplicity I think it's reasonable to define the count as unsigned.