### PR TITLE
Remove the statement/expression distinction.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -231,7 +231,6 @@ WebAssembly offers basic structured control flow with the following constructs.
 Since all AST nodes are expressions in WebAssembly, control constructs may yield
 a value and may appear as children of other expressions.
 
- * `nop`: empty operator that does not yield a value
  * `block`: a fixed-length sequence of expressions with a label at the end
  * `loop`: a block with an additional label at the beginning which may be used to form loops
  * `if`: if expression with a *then* expression
@@ -256,7 +255,7 @@ loop from outside it. This restriction ensures all control flow graphs are well-
 
 ### Yielding values from control constructs
 
-The `nop`, `if`, `br`, `br_if`, `case`, and `return` constructs do not yield values.
+The `if`, `br`, `br_if`, `case`, and `return` constructs do not yield values.
 Other control constructs may yield values if their subexpressions yield values:
 
 * `block`: yields either the value of the last expression in the block or the result of an inner `br` that targeted the label of the block

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -229,7 +229,7 @@ others, etc.
 
 WebAssembly offers basic structured control flow with the following constructs.
 Since all AST nodes are expressions in WebAssembly, control constructs may yield
-a value and appear as children of other expressions.
+a value and may appear as children of other expressions.
 
  * `block`: a fixed-length sequence of expressions with a label at the end
  * `loop`: a block with an additional label at the beginning which may be used to form loops

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -231,6 +231,7 @@ WebAssembly offers basic structured control flow with the following constructs.
 Since all AST nodes are expressions in WebAssembly, control constructs may yield
 a value and may appear as children of other expressions.
 
+ * `nop`: an empty operation that does not yield a value
  * `block`: a fixed-length sequence of expressions with a label at the end
  * `loop`: a block with an additional label at the beginning which may be used to form loops
  * `if`: if expression with a *then* expression
@@ -242,25 +243,27 @@ a value and may appear as children of other expressions.
  * `case`: a case which must be an immediate child of `tableswitch`
  * `return`: return zero or more values from this function
 
-### Nesting of branches
+### Branches and nesting
 
-References to labels must occur within an *enclosing construct* that defined
-the label. This means that references to an AST node's label can only happen
-within descendents of the node in the tree. For example, references to a
-`block`'s label can only occur within the `block`'s body. In practice,
-one can arrange `block`s to put labels wherever one wants to jump to, except
-for one restriction: one can't jump into the middle of a loop from outside
-it. This restriction ensures the well-structured property discussed below.
+The `br` and `br_if` constructs express low-level branching.
+Branches that exit a `block`, `loop`, or `tableswitch` may take a subexpression
+that yields a value for the exited construct.
+Branches may only reference labels defined by an outer *enclosing construct*.
+This means that, for example, references to a `block`'s label can only occur 
+within the `block`'s body. In practice, outer `block`s can be used to place labels for any
+given branching pattern, except for one restriction: one can't branch into the middle of a
+loop from outside it. This restriction ensures all control flow graphs are well-structured.
 
 ### Yielding values from control constructs
 
-The `if`, `br`, `br_if`, `case`, and `return` constructs do not yield values.
+The `nop`, `if`, `br`, `br_if`, `case`, and `return` constructs do not yield values.
 Other control constructs may yield values if their subexpressions yield values:
 
 * `block`: yields either the value of the last expression in the block or the result of an inner `br` that targeted the label of the block
 * `loop`: yields either the value of the last expression in the loop or the result of an inner `br` that targeted the end label of the loop
 * `if_else`: yields either the value of the true expression or the false expression
 * `tableswitch`: yields either the value of the last case or the result of an inner `br` that targeted the tableswitch
+
 
 ### Tableswitch
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -231,7 +231,7 @@ WebAssembly offers basic structured control flow with the following constructs.
 Since all AST nodes are expressions in WebAssembly, control constructs may yield
 a value and may appear as children of other expressions.
 
- * `nop`: an empty operation that does not yield a value
+ * `nop`: empty operator that does not yield a value
  * `block`: a fixed-length sequence of expressions with a label at the end
  * `loop`: a block with an additional label at the beginning which may be used to form loops
  * `if`: if expression with a *then* expression

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -65,9 +65,9 @@ WebAssembly has the following *value types*:
   * `f32`: 32-bit floating point
   * `f64`: 64-bit floating point
 
-Each parameter and local variable has exactly one value type. Function signatures
-consist of a sequence of zero or more parameter types and a sequence zero or more return
-types. (In the MVP, a function can have at most one return type).
+Each parameter and local variable has exactly one [value type](AstSemantics.md#types). Function signatures
+consist of a sequence of zero or more parameter types and a sequence of zero or more return
+types. (Note: in the MVP, a function can have at most one return type).
 
 Note that the value types `i32` and `i64` are not inherently signed or
 unsigned. The interpretation of these types is determined by individual


### PR DESCRIPTION
This catches the design repo up to the spec and implementation repositories where all AST nodes are expressions.