### PR TITLE
add more comprehensive overview to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ WebAssembly is currently being designed as an open standard by a [W3C Community 
 
 - **WebAssembly is safe**: WebAssembly describes a memory-safe, sandboxed [execution environment](AstSemantics.md#linear-memory) that may even be implemented inside existing JavaScript virtual machines.  When [embedded in the web](Web.md), WebAssembly will enforce the same-origin and permissions security policies of the browser.
 
-- **WebAssembly is open and debuggable**: WebAssembly is designed to by pretty-printed in a [textual format](TextFormat.md) for debugging, testing, experimenting, optimizing, learning, teaching, and writing programs by hand. The textual format will be used when [viewing the source](FAQ.md#will-webassembly-support-view-source-on-the-web) of wasm modules on the web.
+- **WebAssembly is open and debuggable**: WebAssembly is designed to be pretty-printed in a [textual format](TextFormat.md) for debugging, testing, experimenting, optimizing, learning, teaching, and writing programs by hand. The textual format will be used when [viewing the source](FAQ.md#will-webassembly-support-view-source-on-the-web) of wasm modules on the web.
 
-- **WebAssembly is part of the open web platform**: WebAssembly is designed to maintain the versionless, feature-tested, and backwards-compatible [nature of the web](Web.md). WebAssembly modules will be able to call into and out of the JavaScript context and access browser functionality through the same Web APIs accessible from JavaScript. (WebAssembly also supports [non-web](NonWeb.md) embeddings.)
+- **WebAssembly is part of the open web platform**: WebAssembly is designed to maintain the versionless, feature-tested, and backwards-compatible [nature of the web](Web.md). WebAssembly modules will be able to call into and out of the JavaScript context and access browser functionality through the same Web APIs accessible from JavaScript. WebAssembly also supports [non-web](NonWeb.md) embeddings.
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ WebAssembly is currently being designed as an open standard by a [W3C Community 
 
 The actual WebAssembly specification is being developed in the [spec repository](https://github.com/WebAssembly/spec/). For now, high-level design discussions should continue to be held in the design repository, via issues and pull requests, so that the spec work can remain focused.
 
-We've mapped out features we expect to ship: 1. In [the Minimum Viable Product (MVP)](MVP.md); 2. Closely [after the MVP](PostMVP.md); 3. In [future versions](FutureFeatures.md).
+We've mapped out features we expect to ship:
+
+ 1. In [the Minimum Viable Product (MVP)](MVP.md);
+ 2. Closely [after the MVP](PostMVP.md);
+ 3. In [future versions](FutureFeatures.md).
 
 Join us:
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,42 @@
-# WebAssembly Community Group: Design
+# WebAssembly Design
 
-This repository contains documents describing the high-level design of
-WebAssembly and is part of the 
-[WebAssembly Community Group](https://www.w3.org/community/webassembly/).
+> This repository contains documents describing the design and high-level overview of WebAssembly.
 
-The actual WebAssembly specification is being developed in the
-[spec repository](https://github.com/WebAssembly/spec/). High-level design
-discussions should continue to be held in the design repository for now so
-that the spec work can remain focused.
+> The documents and discussions in this repository are part of the [WebAssembly Community Group](https://www.w3.org/community/webassembly/).
 
-**Expect the contents to be in flux: everything is still tentative.**
+## Overview
 
-A good starting point is the [high-level design goals](HighLevelGoals.md),
-followed by the [FAQ](FAQ.md).
+WebAssembly or wasm is a portable, low-level, binary-format abstract syntax tree designed as an efficient target language for compilers.
 
-We've mapped out features we expect to ship:
- 1. In [the Minimum Viable Product (MVP)](MVP.md);
- 2. Closely [after the MVP](PostMVP.md);
- 3. In [future versions](FutureFeatures.md).
+WebAssembly is currently being designed as an open standard by a [W3C Community Group](https://www.w3.org/community/webassembly/) that includes representatives from all major browsers. *Expect the contents of this repository to be in flux: everything is still under discussion.*
+
+- **WebAssembly is efficient and fast**: The wasm [AST](AstSemantics.md) is designed to be encoded in a size- and load-time-efficient [binary format](BinaryEncoding.md). WebAssembly aims to execute at native speed by taking advantage of [common hardware capabilities](Portability.md#assumptions-for-efficient-execution) available on a wide range of platforms.
+
+- **WebAssembly is safe**: WebAssembly describes a memory-safe, sandboxed [execution environment](AstSemantics.md#linear-memory) that may even be implemented inside existing JavaScript virtual machines.  When [embedded in the web](Web.md), WebAssembly will enforce the same-origin and permissions security policies of the browser.
+
+- **WebAssembly is open and debuggable**: WebAssembly is designed to by pretty-printed in a [textual format](TextFormat.md) for debugging, testing, experimenting, optimizing, learning, teaching, and writing programs by hand. The textual format will be used when [viewing the source](FAQ.md#will-webassembly-support-view-source-on-the-web) of wasm modules on the web.
+
+- **WebAssembly is part of the open web platform**: WebAssembly is designed to maintain the versionless, feature-tested, and backwards-compatible [nature of the web](Web.md). WebAssembly modules will be able to call into and out of the JavaScript context and access browser functionality through the same Web APIs accessible from JavaScript. (WebAssembly also supports [non-web](NonWeb.md) embeddings.)
+
+## More Information
+
+| Resource                                   | Repository Location      |
+|--------------------------------------------|--------------------------|
+| High Level Goals                           | [design/HighLevelGoals.md](HighLevelGoals.md) |
+| Frequently Asked Questions                 | [design/FAQ.md](FAQ.md)            |
+| Language Spec (in progress)                | [spec/README.md](https://github.com/WebAssembly/spec)           |
+| End-to-end prototypes (C++ to browser VMs) | [wasm-e2e/README.md](https://github.com/WebAssembly/wasm-e2e)       |
+
+## Design Process & Contributing
+
+The actual WebAssembly specification is being developed in the [spec repository](https://github.com/WebAssembly/spec/). For now, high-level design discussions should continue to be held in the design repository, via issues and pull requests, so that the spec work can remain focused.
+
+We've mapped out features we expect to ship: 1. In [the Minimum Viable Product (MVP)](MVP.md); 2. Closely [after the MVP](PostMVP.md); 3. In [future versions](FutureFeatures.md).
 
 Join us:
- * On IRC: `irc://irc.w3.org:6667/#webassembly`
- * [Contribute](Contributing.md)!
 
-When contributing, please follow our
-[Code of Ethics and Professional Conduct](CodeOfConduct.md).
+ * in the [W3C Community Group](https://www.w3.org/community/webassembly/)
+ * on IRC: `irc://irc.w3.org:6667/#webassembly`
+ * by [contributing](Contributing.md)!
+
+When contributing, please follow our [Code of Ethics and Professional Conduct](CodeOfConduct.md).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-WebAssembly or wasm is a portable, low-level, binary-format abstract syntax tree designed as an efficient target language for compilers.
+WebAssembly or wasm is a new, portable, size- and load-time-efficient format suitable for compilation to the web.
 
 WebAssembly is currently being designed as an open standard by a [W3C Community Group](https://www.w3.org/community/webassembly/) that includes representatives from all major browsers. *Expect the contents of this repository to be in flux: everything is still under discussion.*
 


### PR DESCRIPTION
We've been using the design repo as an unofficial homepage for the project (e.g. as our organization's URL) and it's the most likely thing that newcomers to the project will see first.  I tried to add a more comprehensive project overview to the `README.md`.

I added an overview section and attempted to highlight a few of WebAssembly's major features.  I also added a section with useful links to other documents in the design repo as well as other repos in the organization.

Feedback welcome.