### PR TITLE
Add a br_unless instruction.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -262,11 +262,12 @@ a value and may appear as children of other expressions.
  * `br`: branch to a given label in an enclosing construct
  * `br_if`: conditionally branch to a given label in an enclosing construct
  * `br_table`: a jump table which jumps to a label in an enclosing construct
+ * `br_unless`: same as `br_if` but branches if the condition is false instead
  * `return`: return zero or more values from this function
 
 ### Branches and nesting
 
-The `br` and `br_if` constructs express low-level branching.
+The `br`, `br_if`, and `br_unless` constructs express low-level branching.
 Branches may only reference labels defined by an outer *enclosing construct*.
 This means that, for example, references to a `block`'s label can only occur 
 within the `block`'s body.
@@ -285,7 +286,7 @@ before any others.
 
 ### Yielding values from control constructs
 
-The `nop`, `if`, `br`, `br_if`, and `return` constructs do not yield values.
+The `nop`, `if`, `br`, `br_if`, `br_unless`, and `return` constructs do not yield values.
 Other control constructs may yield values if their subexpressions yield values:
 
 * `block`: yields either the value of the last expression in the block or the result of an inner `br` that targeted the label of the block


### PR DESCRIPTION
This is the same as br_if, but with an inverted condition.

This is useful for low-level tools that wish to invert a branch condition in place, for example to rearrange basic blocks while being otherwise minimally invasive. Having both `br_if` and `br_unless` means that this is possible just by rewriting the opcode. If course, it is possible to invert a condition explicitly without this, although in many cases it requires inserting new AST nodes.
