### PR TITLE
Make tableswitch trap on out of bounds, rather than having a default.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -267,9 +267,9 @@ Other control constructs may yield values if their subexpressions yield values:
 
 ### Tableswitch
 
-A `tableswitch` consists of a zero-based array of targets, a *default* target, an index
+A `tableswitch` consists of a zero-based array of targets, an index
 operand, and a list of `case` nodes. Targets may be either labels or `case` nodes.
-A `tableswitch` jumps to the target indexed in the array or the default target if the index is out of bounds. 
+A `tableswitch` jumps to the target indexed in the array, or traps if the index is out of bounds.
 
 A `case` node consists of an expression and may be referenced multiple times
 by the parent `tableswitch`. Unless exited explicitly, control falls through a `case` 

--- a/Rationale.md
+++ b/Rationale.md
@@ -138,6 +138,14 @@ Also,
 [more expressive control flow constructs](FutureFeatures.md#more-expressive-control-flow)
 may be added in the future.
 
+The `tableswitch` instruction traps if the index is out of bounds rather than
+having a builtin "default" destination. Applications can perform their own
+range check if they require one. This does oblidge optimizing JITs to do more
+work to optimize away its own range checks, but the upside of making
+`tableswitch` be conceptually just a jump table, and not a jump table with an
+extra branch folded in, and it enables engines that have ways of doing the
+range check without using a branch to emit switches that have no branching at
+all in situations where the application itself doesn't need a default.
 
 ## Locals
 


### PR DESCRIPTION
This is the idea described in https://github.com/WebAssembly/spec/pull/163 , making `tableswitch` trap if the index is out of bounds rather than having an explicit default. This makes `tableswitch` simpler and conceptually closer to being "just a jump table", and is consistent with other constructs in WebAssembly (trap on out of bounds, instead of having default behavior).

The main downside is that in cases when an application emits a range check branch for itself, and the JIT uses a branch to implement the bounds check, we'd get two branches checking the range rather than one. Clever JITs could optimize this away, but simple JITs might not.

Despite my general interest in simple JITs, the factor that I think tips the balance in this case is that `tableswitch` is very infrequent relative to most other instructions, so a simple JIT aiming to be as fast as possible should be able to do extra work to recognize the common patterns where it can elide its own branch without a significant overall slowdown.