### PR TITLE
Reorder select's operands to put the condition last.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -550,10 +550,9 @@ outside the range which rounds to an integer in range) traps.
 
 ## Type-parameterized operators.
 
-  * `select`: a ternary operator with a boolean (i32) condition and two
-    additional operands, which must have the same type as each other. `select`
-    returns the the first of these two operands if the condition operand is
-    non-zero, or the second otherwise.
+  * `select`: a ternary operator with two operands, which have the same type as
+    each other, plus a boolean (i32) condition. `select` returns the first
+    operand if the condition operand is non-zero, or the second otherwise.
 
 ## Feature test
 

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -246,13 +246,15 @@ a value and may appear as children of other expressions.
 ### Branches and nesting
 
 The `br` and `br_if` constructs express low-level branching.
-Branches that exit a `block`, `loop`, or `tableswitch` may take a subexpression
-that yields a value for the exited construct.
 Branches may only reference labels defined by an outer *enclosing construct*.
 This means that, for example, references to a `block`'s label can only occur 
 within the `block`'s body. In practice, outer `block`s can be used to place labels for any
 given branching pattern, except for one restriction: one can't branch into the middle of a
 loop from outside it. This restriction ensures all control flow graphs are well-structured.
+
+Branches that exit a `block`, `loop`, or `tableswitch` may take a subexpression
+that yields a value for the exited construct. If present, it is the first operand
+before any others.
 
 ### Yielding values from control constructs
 


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/design/pull/469, this PR proposes reordering select's operands to put the condition last. This allows it to evaluate the condition last under the common evaluation rules, which is expected to enable more optimization opportunities.