### PR TITLE
Factor a `multiblock` node out of `tableswitch`.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -232,54 +232,66 @@ Since all AST nodes are expressions in WebAssembly, control constructs may yield
 a value and may appear as children of other expressions.
 
  * `nop`: an empty operator that does not yield a value 
- * `block`: a fixed-length sequence of expressions with a label at the end
+ * `block`: a sequence of expressions with a label at the end
  * `loop`: a block with an additional label at the beginning which may be used to form loops
+ * `multiblock`: a mixed sequence of expressions and `label` nodes, with a label at the end
+ * `label`: a node which defines a label and must be an immediate child of `multiblock`
  * `if`: if expression with a *then* expression
  * `if_else`: if expression with *then* and *else* expressions
- * `br`: branch to a given label in an enclosing construct
- * `br_if`: conditionally branch to a given label in an enclosing construct
- * `tableswitch`: a jump table which may jump either to an immediate `case`
-                  child or to a label in an enclosing construct
- * `case`: a case which must be an immediate child of `tableswitch`
+ * `br`: branch to a given in-scope label
+ * `br_if`: conditionally branch to a given in-scope label
+ * `tableswitch`: branch using a "jump table" of in-scope labels
  * `return`: return zero or more values from this function
 
 ### Branches and nesting
 
-The `br` and `br_if` constructs express low-level branching.
-Branches that exit a `block`, `loop`, or `tableswitch` may take a subexpression
-that yields a value for the exited construct.
-Branches may only reference labels defined by an outer *enclosing construct*.
-This means that, for example, references to a `block`'s label can only occur 
-within the `block`'s body.
+The `br`, `br_if`, and `tableswitch` constructs express low-level branching. The
+`block`, `loop`, and `multiblock` constructs provide labels that may be branched
+to.
 
-In practice, outer `block`s can be used to place labels for any given branching
-pattern, except for one restriction: one can't branch into the middle of a loop
-from outside it. This restriction ensures all control flow graphs are well-structured
+Branches may only reference labels that are *in scope*. The labels in `block`
+and `loop` nodes are in scope only within their subtrees. The labels in
+`multiblock` nodes are only in scope only within their subtrees, and only in
+subtrees earlier in the `multiblock` than their definition. This restriction
+ensures all control flow graphs are
+[reducible](http://dl.acm.org/citation.cfm?id=804919).
+
+In terms of control flow graphs, the reducible requirement imposes
+only one effective restriction: loops can only be entered from the
+top, and not from a branch into the middle. This restriction ensures
+all control flow graphs are well-structured
 in the exact sense as in high-level languages like Java, JavaScript, Rust and Go. To
 further see the parallel, note that a `br` to a `block`'s label is functionally
 equivalent to a labeled `break` in high-level languages in that a `br` simply
 breaks out of a `block`.
 
+Branches may take a subexpression as an optional first operand (before any
+other operands). When a `block`, `multiblock`, or `loop` is exited by a branch,
+or when a `label` is branched to by a branch, this operand of the branch is
+yielded as the result. When `br_if`'s condition is false, this operand is
+yielded as `br_if`'s result.
+
 ### Yielding values from control constructs
 
-The `nop`, `if`, `br`, `br_if`, `case`, and `return` constructs do not yield values.
+The `nop` and `if` constructs do not yield values.
 Other control constructs may yield values if their subexpressions yield values:
 
-* `block`: yields either the value of the last expression in the block or the result of an inner `br` that targeted the label of the block
-* `loop`: yields either the value of the last expression in the loop or the result of an inner `br` that targeted the end label of the loop
+* `block`: yields either the value of the last expression in the block or the
+   result of an inner branch that branched to the label of the `block`
+* `loop`: yields either the value of the last expression in the loop or the
+   result of an inner branch that branched to the end label of the `loop`
+* `multiblock`: yields either the value of the last expression in the
+   `multiblock` or the result of an inner branch that branched to the end label
+   of the `multiblock`
+* `label`: yields either the value of the prior expression in the parent `multiblock` or the result of a branch that branched to the `label`
 * `if_else`: yields either the value of the true expression or the false expression
-* `tableswitch`: yields either the value of the last case or the result of an inner `br` that targeted the tableswitch
 
 
 ### Tableswitch
 
-A `tableswitch` consists of a zero-based array of targets, a *default* target, an index
-operand, and a list of `case` nodes. Targets may be either labels or `case` nodes.
-A `tableswitch` jumps to the target indexed in the array or the default target if the index is out of bounds. 
-
-A `case` node consists of an expression and may be referenced multiple times
-by the parent `tableswitch`. Unless exited explicitly, control falls through a `case` 
-to the next `case` or the end of the `tableswitch`.
+A `tableswitch` consists of a zero-based array of labels, a *default* label, and an
+index operand. A `tableswitch` branches to the label indexed in the array or the
+default label if the index is out of bounds.
 
 
 ## Calls


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/design/issues/480, this introduces `multiblock`, and simplifies `tableswitch` accordingly.

This also updates the wording around control flow operators in several areas.