### PR TITLE
Make the sign bit of a new NaN value nondeterministic.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -447,9 +447,9 @@ follows:
  - If the operation has multiple NaN input values, the result value is computed
    as if one of the operands, selected nondeterministically, is the only NaN
    operand (as described in the previous rule).
- - If the operation has no NaN input values, the result value has a sign bit of
-   0 and a fraction field with 1 in the most significant bit and 0 in the
-   remaining bits.
+ - If the operation has no NaN input values, the result value has a
+   nondeterministic sign bit, a fraction field with 1 in the most significant
+   bit and 0 in the remaining bits.
 
 32-bit floating point operations are as follows:
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -35,6 +35,9 @@ currently admits nondeterminism:
    multiple NaN input values with differing bit patterns, it is nondeterminsitic
    which bit pattern is used as the basis for the result (as it is in
    IEEE 754-2008).
+ * Except when otherwise specified, when an arithmetic operator with a floating
+   point result type receives no NaN input values and produces a NaN result
+   value, the sign bit of the NaN result value is nondeterministic.
  * [Fixed-width SIMD may want some flexibility](PostMVP.md#fixed-width-simd)
    - In SIMD.js, floating point values may or may not have subnormals flushed to
      zero.

--- a/Rationale.md
+++ b/Rationale.md
@@ -292,7 +292,8 @@ However, since the publication of IEEE 754-2008, MIPS has added a configuration
 mode (NAN2008) which enables support for the new rules.
 
 In particular, the sign bit of generated NaNs is nondeterministic since x86
-NaNs with it set to 1 while other architectures generate NaNs with it set to 0.
+generates NaNs with it set to 1 while other architectures generate NaNs with it
+set to 0.
 
 
 ## Integer operations

--- a/Rationale.md
+++ b/Rationale.md
@@ -291,6 +291,9 @@ notably MIPS, historically behaved differently than other architectures.
 However, since the publication of IEEE 754-2008, MIPS has added a configuration
 mode (NAN2008) which enables support for the new rules.
 
+In particular, the sign bit of generated NaNs is nondeterministic since x86
+NaNs with it set to 1 while other architectures generate NaNs with it set to 0.
+
 
 ## Integer operations
 


### PR DESCRIPTION
x86 produces NaN values with the sign bit set to 1, and other architectures
produce NaN values with the sign bit set to 0; wasm can model this by
just making the sign bit nondeterminisitc. This should still permit the
NaN-boxing technique that all this NaN bit-pattern language is intended to
support.

This addresses #477.