### PR TITLE
Add a proposal to BinaryEncoding.md

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -157,4 +157,4 @@ conflict-avoidance practices surrounding string names:
 
 The native prototype built for [V8](https://github.com/WebAssembly/v8-native-prototype)
 implements a binary format that embodies most, but not all of the ideas in this document.
-It is described in detail in a [public design doc](https://docs.google.com/a/google.com/document/d/1761v1AfhFM5kE8NArF_PyXcl-iVh0Dx3InOrmcyIoiI/pub).
+It is described in detail in a [public design doc](https://docs.google.com/a/google.com/document/d/1761v1AfhFM5kE8NArF_PyXcl-iVh0Dx3InOrmcyIoiI/pub) and a [copy of the original](https://docs.google.com/document/d/1-G11CnMA0My20KI9D7dBR6ZCPOBCRD0oCH6SHCPFGx0/edit?usp=sharing).

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -153,3 +153,8 @@ conflict-avoidance practices surrounding string names:
       or affect anything outside of the initialization of the index spaces; decoders would
       remain versionless and simply add cases for new *names* (as with current JavaScript parsers).
 
+## Proposals
+
+The native prototype built for [V8](https://github.com/WebAssembly/v8-native-prototype)
+implements a binary format that embodies most, but not all of the ideas in this document.
+It is described in detail in a [public design doc](https://docs.google.com/a/google.com/document/d/1761v1AfhFM5kE8NArF_PyXcl-iVh0Dx3InOrmcyIoiI/pub).


### PR DESCRIPTION
I've written a design document detailing the prototype binary format built for V8. It is meant as a starting point for discussion. It is complete as far as the design repository up to today (Dec 8, 2015). It has several enhancements and refactorings possible, most of which are noted in the document linked here (https://docs.google.com/a/google.com/document/d/1761v1AfhFM5kE8NArF_PyXcl-iVh0Dx3InOrmcyIoiI/pub).

We intend to keep iterating on the design and I will file an issue to track discussions there.

Apologies if permissions on the document are not properly set for the entire audience. It is intended to be public, so please ping me or the issue if it is not accessible. 