### PR TITLE
Added a link to the FAQ to state why LLVM is chosen now

### DIFF
--- a/HighLevelGoals.md
+++ b/HighLevelGoals.md
@@ -33,6 +33,6 @@
 4. Design to support [non-browser embeddings](NonWeb.md) as well.
 5. Make a great platform:
     * build a new LLVM backend for WebAssembly and an accompanying
-      clang port;
+      clang port ([why LLVM first?](FAQ.md#which-compilers-can-i-use-to-build-webassembly-programs));
     * promote other compilers and tools targeting WebAssembly; and
     * enable other useful [tooling](Tooling.md).


### PR DESCRIPTION
Thought this would be better to really push on the fact that LLVM is chosen because that is where our speciality/knowledge is but we would love to see more compilers embrace WebAssembly