### PR TITLE
Remove `comma` and `conditional`

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -358,15 +358,6 @@ supported (including NaN values of all possible bit patterns).
   * `f32.const`: produce the value of an f32 immediate
   * `f64.const`: produce the value of an f64 immediate
 
-## Expressions with Control Flow
-
-  * `comma`: evaluate and ignore the result of the first operand, evaluate and
-    return the second operand
-  * `conditional`: basically ternary `?:` operator
-
-New operators may be considered which allow measurably greater
-expression-tree-building opportunities.
-
 ## 32-bit Integer operators
 
 Integer operators are signed, unsigned, or sign-agnostic. Signed operators

--- a/FeatureTest.md
+++ b/FeatureTest.md
@@ -37,7 +37,7 @@ To illustrate, consider 4 examples:
 
 * [`i32.min_s`](FutureFeatures.md#additional-integer-operators) - Strategy 2
   could be used to translate `(i32.min_s lhs rhs)` into an equivalent expression
-  that stores `lhs` and `rhs` in locals then uses `i32.lt_s` and `conditional`.
+  that stores `lhs` and `rhs` in locals then uses `i32.lt_s` and `select`.
 * [Threads](PostMVP.md#threads) - If an application uses `#ifdef` extensively
   to produce thread-enabled/disabled builds, Strategy 1 would be appropriate.
   However, if the application was able to abstract use of threading to a few

--- a/GC.md
+++ b/GC.md
@@ -34,8 +34,8 @@ type is to be passed to and returned from exported functions.
 
 Reference types are allowed to be used as the types of locals, parameters
 and return types. Additionally, references would be allowed as operands to
-operators that treat their values as black boxes (`conditional`, `comma`, 
-`eq`, etc.). A new `dynamic_cast` operator would be added to allow checked
+operators that treat their values as black boxes (`br`, `block`, etc.).
+A new `dynamic_cast` operator would be added to allow checked
 casting from any opaque reference type to any other opaque reference type.
 Whether the cast succeeds is up to the host environment; WebAssembly itself
 will define no a priori subtyping relationship.

--- a/Rationale.md
+++ b/Rationale.md
@@ -221,9 +221,9 @@ tables filled with failure handlers to avoid one check.
 ## Expressions with Control Flow
 
 Expression trees offer significant size reduction by avoiding the need for
-`set_local`/`get_local` pairs in the common case of an expression with only one,
-immediate use. The `comma` and `conditional` primitives provide AST nodes that
-express control flow and thus allow more opportunities to build bigger
+`set_local`/`get_local` pairs in the common case of an expression with only one
+immediate use. Control flow "statements" are in fact expressions with result
+values, thus allowing even more opportunities to build bigger
 expression trees and further reduce `set_local`/`get_local` usage (which
 constitute 30-40% of total bytes in the
 [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1)).


### PR DESCRIPTION
With #464 removing the statement/expression distinction, there's no longer a need for `comma` and `conditional`.