### PR TITLE
Move dynamic linking from FutureFeatures.md to PostMVP.md

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -11,10 +11,6 @@ available under [feature tests](FeatureTest.md).
 
 This is covered in the [tooling](Tooling.md) section.
 
-## Dynamic linking
-
-This is covered in the [dynamic linking](DynamicLinking.md) section.
-
 ## Finer-grained control over memory
 
 Provide access to safe OS-provided functionality including:

--- a/PostMVP.md
+++ b/PostMVP.md
@@ -32,6 +32,10 @@ and can thus be represented efficiently by the engine.
   [PNaCl atomic support]: https://developer.chrome.com/native-client/reference/pnacl-c-cpp-language-support#memory-model-and-atomics
   [SharedArrayBuffer]: https://docs.google.com/document/d/1NDGA_gZJ7M7w1Bh8S0AoDyEqwDdRh4uSoTPSNn77PFk
 
+## Dynamic linking
+
+This is covered in the [dynamic linking](DynamicLinking.md) section.
+
 ## Fixed-width SIMD
 
 Support fixed-width SIMD vectors, initially only for 128-bit wide vectors as


### PR DESCRIPTION
This better reflects what I believe is the shared priority that dynamic linking is in the set of features to do "right after" we finish/ship the MVP.