### PR TITLE
Change start to receive any function index to be its start function

### DIFF
--- a/Modules.md
+++ b/Modules.md
@@ -140,11 +140,11 @@ For example, a start node in a module will be:
 
 or
 
-```(start 0)```
+```(start <int>)```
 
 In the first example, the environment is expected to call the function $start_function
 before calling any other module function. In the second case, the environment is
-expected to call the module function indexed 0.
+expected to call the module function indexed <int> (this index starts from 0).
 
 A module can:
 * Only have at most a start node

--- a/Modules.md
+++ b/Modules.md
@@ -144,7 +144,7 @@ or
 
 In the first example, the environment is expected to call the function $start_function
 before calling any other module function. In the second case, the environment is
-expected to call the module function indexed <int> (this index starts from 0).
+expected to call the module function indexed `<int>` (this index starts from 0).
 
 A module can:
 * Only have at most a start node

--- a/Modules.md
+++ b/Modules.md
@@ -140,11 +140,11 @@ For example, a start node in a module will be:
 
 or
 
-```(start <int>)```
+```(start 42)```
 
 In the first example, the environment is expected to call the function $start_function
 before calling any other module function. In the second case, the environment is
-expected to call the module function indexed `<int>` (this index starts from 0).
+expected to call the module function indexed 42. This number is the function index starting from 0 (same as for `export`).
 
 A module can:
 * Only have at most a start node


### PR DESCRIPTION
Since this makes it more flexible and similar to the existing `(export <int>)` construct, I would like to change `start` to accept any index number to the function instead of allowing just zero `(start 0)`