### PR TITLE
Update BinaryFormat with details about encoding

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -16,12 +16,7 @@ The encoding is split into three layers:
   The structural compression introduces more efficient encoding of values, 
   rearranges values within the module, and prunes structurally identical
   tree nodes.
-* **Layer 2** applies generic compression techniques, already available
-  in browsers and other tooling. Algorithms as simple as gzip can deliver
-  good results, but more sophisticated algorithms like 
-  [LZHAM](https://github.com/richgel999/lzham_codec) and
-  [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/) are able
-  to deliver dramatically smaller files.
+* **Layer 2** Layer 2 applies generic compression algorithms, like [gzip](http://www.gzip.org/) and [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/), that are already available in browsers and other tooling.
 
 Most importantly, the layering approach allows development and standardization to
 occur incrementally. For example, Layer 1 and Layer 2 encoding techniques can be

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -199,3 +199,13 @@ first byte, before the child nodes.
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
 | `nop` | `0x00` | | no operation |
+| `block` | `0x01` | count = `varuint32` | a sequence of expressions, the last of which yields a value |
+| `loop` | `0x02` | count = `varuint32` | a block which can also form control flow loops |
+| `if` | `0x03` | | high-level one-armed if |
+| `if_else` | `0x04` | | high-level two-armed if |
+| `select` | `0x05` | | select one of two values based on condition |
+| `br` | `0x06` | relative_depth = `uint8` | break that targets a outer nested block |
+| `br_if` | `0x07` | relative_depth = `uint8` | conditional break that targets a outer nested block |
+| `tableswitch` | 0x08 | `tableswitch_operand` | tableswitch control flow construct |
+| `return` | 0x14 | | return zero or one value from this function |
+| `unreachable` | 0x15 | | trap immediately |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -194,7 +194,7 @@ Each node in the abstract syntax tree corresponds to an operator, such as `i32.a
 Most operators encode as a single `uint8`, but some require *immediates* which immediately follow the
 first byte, before the child nodes.
 
-## Control flow operators
+## Control flow operators ([described here](AstSemantics.md#control-flow-structures))
 
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
@@ -220,7 +220,7 @@ The `tableswitch` operator has as complex immediate operand which is encoded as 
 
 The table switch operator is then immediately followed by `case_count` case expressions which by default fall through to each other.
 
-## Basic operators
+## Basic operators ([described here](AstSemantics.md#constants))
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
 | `i8.const` | `0x09` | value = `uint8` | a constant value, signed extended to type `i32`  |
@@ -235,7 +235,7 @@ The table switch operator is then immediately followed by `case_count` case expr
 | `call_function` | `0x12` | function_index = `varuint32` | call a function by its index |
 | `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
 
-## Memory-related operators
+## Memory-related operators ([described here](AstSemantics.md#linear-memory-accesses))
 
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
@@ -272,7 +272,7 @@ The `memory_immediate` type is encoded as follows:
 | flags | `uint8` | always | a bitfield where<br>bit `4` indicates an offset follows<br>bit `7` indicates natural alignment |
 | offset | `varuint32` | `flags[4] == 1` | the value of the offset |
 
-## Simple operators
+## Simple operators ([described here](AstSemantics#32-bit-integer-operators))
 
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -216,7 +216,7 @@ The `tableswitch` operator has as complex immediate operand which is encoded as 
 | ---- | ---- | ---- |
 | case_count | `uint16` | number of cases in the case_table |
 | target_count | `uint16` | number of targets in the target_table |
-| target_table | `uint16*` | target entries where<br>`>= 0x800` indicates an outer block to which to break<br>`<= 0x8000` indicates a case to which to jump |
+| target_table | `uint16*` | target entries where<br>`>= 0x8000` indicates an outer block to which to break<br>`<= 0x8000` indicates a case to which to jump |
 
 The table switch operator is then immediately followed by `case_count` case expressions which by default fall through to each other.
 
@@ -235,5 +235,164 @@ The table switch operator is then immediately followed by `case_count` case expr
 | `call_function` | `0x12` | function_index = `varuint32` | call a function by its index |
 | `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
 
+## Memory-related operators
+
+| Name | Opcode | Immediate | Description |
+| ---- | ---- | ---- | ---- |
+| `i32.load8_s` | `0x20` | `memory_immediate` | load from memory |
+| `i32.load8_u` | `0x21` | `memory_immediate` | load from memory  |
+| `i32.load16_s` | `0x22` | `memory_immediate` | load from memory |
+| `i32.load16_u` | `0x23` | `memory_immediate` | load from memory |
+| `i64.load8_s` | `0x24` | `memory_immediate` | load from memory |
+| `i64.load8_u` | `0x25` | `memory_immediate` | load from memory |
+| `i64.load16_s` | `0x26` | `memory_immediate` | load from memory |
+| `i64.load16_u` | `0x27` | `memory_immediate` | load from memory |
+| `i64.load32_s` | `0x28` | `memory_immediate` | load from memory |
+| `i64.load32_u` | `0x29` | `memory_immediate` | load from memory |
+| `i32.load` | `0x2a` | `memory_immediate` | load from memory |
+| `i64.load` | `0x2b` | `memory_immediate` | load from memory |
+| `f32.load` | `0x2c` | `memory_immediate` | load from memory |
+| `f64.load` | `0x2d` | `memory_immediate` | load from memory |
+| `i32.store8` | `0x2e` | `memory_immediate` | store to memory |
+| `i32.store16` | `0x2f` | `memory_immediate` | store to memory |
+| `i64.store8` | `0x30` | `memory_immediate` | store to memory |
+| `i64.store16` | `0x31` | `memory_immediate` | store to memory |
+| `i64.store32` | `0x32` | `memory_immediate` | store to memory |
+| `i32.store` | `0x33` | `memory_immediate` | store to memory |
+| `i64.store` | `0x34` | `memory_immediate` | store to memory |
+| `f32.store` | `0x35` | `memory_immediate` | store to memory |
+| `f64.store` | `0x36` | `memory_immediate` | store to memory |
+| `memory_size` | `0x3b` |  | query the size of memory |
+| `grow_memory` | `0x39` |  | grow the size of memory |
+
+The `memory_immediate` type is encoded as follows:
+
+| Name | Type | Present? | Description |
+| ---- | ---- | ---- | ---- |
+| flags | `uint8` | always | a bitfield where<br>bit `4` indicates an offset follows<br>bit `7` indicates natural alignment |
+| offset | `varuint32` | `flags[4] == 1` | the value of the offset |
+
+## Simple operators
+
+| Name | Opcode | Immediate | Description |
+| ---- | ---- | ---- | ---- |
+| `i32.add` | `0x40` | | |
+| `i32.sub` | `0x41` | | |
+| `i32.mul` | `0x42` | | |
+| `i32.div_s` | `0x43` | | |
+| `i32.div_u` | `0x44` | | |
+| `i32.rem_s` | `0x45` | | |
+| `i32.rem_u` | `0x46` | | |
+| `i32.and` | `0x47` | | |
+| `i32.ior` | `0x48` | | |
+| `i32.xor` | `0x49` | | |
+| `i32.shl` | `0x4a` | | |
+| `i32.shr_u` | `0x4b` | | |
+| `i32.shr_s` | `0x4c` | | |
+| `i32.eq` | `0x4d` | | |
+| `i32.ne` | `0x4e` | | |
+| `i32.lt_s` | `0x4f` | | |
+| `i32.le_s` | `0x50` | | |
+| `i32.lt_u` | `0x51` | | |
+| `i32.le_u` | `0x52` | | |
+| `i32.gt_s` | `0x53` | | |
+| `i32.ge_s` | `0x54` | | |
+| `i32.gt_u` | `0x55` | | |
+| `i32.ge_u` | `0x56` | | |
+| `i32.clz` | `0x57` | | |
+| `i32.ctz` | `0x58` | | |
+| `i32.popcnt` | `0x59` | | |
+| `bool.not` | `0x5a` | | |
+| `i64.add` | `0x5b` | | |
+| `i64.sub` | `0x5c` | | |
+| `i64.mul` | `0x5d` | | |
+| `i64.div_s` | `0x5e` | | |
+| `i64.div_u` | `0x5f` | | |
+| `i64.rem_s` | `0x60` | | |
+| `i64.rem_u` | `0x61` | | |
+| `i64.and` | `0x62` | | |
+| `i64.ior` | `0x63` | | |
+| `i64.xor` | `0x64` | | |
+| `i64.shl` | `0x65` | | |
+| `i64.shr_u` | `0x66` | | |
+| `i64.shr_s` | `0x67` | | |
+| `i64.eq` | `0x68` | | |
+| `i64.ne` | `0x69` | | |
+| `i64.lt_s` | `0x6a` | | |
+| `i64.le_s` | `0x6b` | | |
+| `i64.lt_u` | `0x6c` | | |
+| `i64.le_u` | `0x6d` | | |
+| `i64.gt_s` | `0x6e` | | |
+| `i64.ge_s` | `0x6f` | | |
+| `i64.gt_u` | `0x70` | | |
+| `i64.ge_u` | `0x71` | | |
+| `i64.clz` | `0x72` | | |
+| `i64.ctz` | `0x73` | | |
+| `i64.popcnt` | `0x74` | | |
+| `f32.add` | `0x75` | | |
+| `f32.sub` | `0x76` | | |
+| `f32.mul` | `0x77` | | |
+| `f32.div` | `0x78` | | |
+| `f32.min` | `0x79` | | |
+| `f32.max` | `0x7a` | | |
+| `f32.abs` | `0x7b` | | |
+| `f32.neg` | `0x7c` | | |
+| `f32.copysign` | `0x7d` | | |
+| `f32.ceil` | `0x7e` | | |
+| `f32.floor` | `0x7f` | | |
+| `f32.trunc` | `0x80` | | |
+| `f32.nearestint` | `0x81` | | |
+| `f32.sqrt` | `0x82` | | |
+| `f32.eq` | `0x83` | | |
+| `f32.ne` | `0x84` | | |
+| `f32.lt` | `0x85` | | |
+| `f32.le` | `0x86` | | |
+| `f32.gt` | `0x87` | | |
+| `f32.ge` | `0x88` | | |
+| `f64.add` | `0x89` | | |
+| `f64.sub` | `0x8a` | | |
+| `f64.mul` | `0x8b` | | |
+| `f64.div` | `0x8c` | | |
+| `f64.min` | `0x8d` | | |
+| `f64.max` | `0x8e` | | |
+| `f64.abs` | `0x8f` | | |
+| `f64.neg` | `0x90` | | |
+| `f64.copysign` | `0x91` | | |
+| `f64.ceil` | `0x92` | | |
+| `f64.floor` | `0x93` | | |
+| `f64.trunc` | `0x94` | | |
+| `f64.nearestint` | `0x95` | | |
+| `f64.sqrt` | `0x96` | | |
+| `f64.eq` | `0x97` | | |
+| `f64.ne` | `0x98` | | |
+| `f64.lt` | `0x99` | | |
+| `f64.le` | `0x9a` | | |
+| `f64.gt` | `0x9b` | | |
+| `f64.ge` | `0x9c` | | |
+| `i32.sconvertf32` | `0x9d` | | |
+| `i32.sconvertf64` | `0x9e` | | |
+| `i32.uconvertf32` | `0x9f` | | |
+| `i32.uconvertf64` | `0xa0` | | |
+| `i32.converti64` | `0xa1` | | |
+| `i64.sconvertf32` | `0xa2` | | |
+| `i64.sconvertf64` | `0xa3` | | |
+| `i64.uconvertf32` | `0xa4` | | |
+| `i64.uconvertf64` | `0xa5` | | |
+| `i64.sconverti32` | `0xa6` | | |
+| `i64.uconverti32` | `0xa7` | | |
+| `f32.sconverti32` | `0xa8` | | |
+| `f32.uconverti32` | `0xa9` | | |
+| `f32.sconverti64` | `0xaa` | | |
+| `f32.uconverti64` | `0xab` | | |
+| `f32.convertf64` | `0xac` | | |
+| `f32.reinterpreti32` | `0xad` | | |
+| `f64.sconverti32` | `0xae` | | |
+| `f64.uconverti32` | `0xaf` | | |
+| `f64.sconverti64` | `0xb0` | | |
+| `f64.uconverti64` | `0xb1` | | |
+| `f64.convertf32` | `0xb2` | | |
+| `f64.reinterpreti64` | `0xb3` | | |
+| `i32.reinterpretf32` | `0xb4` | | |
+| `i64.reinterpretf64` | `0xb5` | | |
 
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -279,7 +279,7 @@ The `memory_immediate` type is encoded as follows:
 
 | Name | Type | Present? | Description |
 | ---- | ---- | ---- | ---- |
-| flags | `uint8` | always | a bitfield where<br>bit `4` indicates an offset follows<br>bit `7` indicates natural alignment |
+| flags | `uint8` | always | a bitfield where<br>bit `4` indicates an offset follows<br>bit `7` indicates natural alignment<br>other bits are reserved for future use |
 | offset | `varuint32` | `flags[4] == 1` | the value of the offset |
 
 ## Simple operators ([described here](AstSemantics#32-bit-integer-operators))

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -58,13 +58,13 @@ Refers to an approach for encoding syntax trees, where each node begins with an 
 sequence, then followed recursively by any child nodes. 
 
 * Examples
-  * Given a simple AST node: `struct I32Add { AstNode *left, *right; }`
-    * First write the binary sequence for `I32Add` (uint8)
+  * Given a simple AST node: `I32Add(left: AstNode, right: AstNode)`
+    * First write the opcode for `I32Add` (uint8)
     * Then recursively write the left and right nodes.
 
-  * Given a call AST node: `struct Call { uint32_t callee_index; vector<AstNode*> args; }`
-    * First write the binary sequence of `Call` (uint8)
-    * Then write the (variable-length) integer `Call::callee_index` (varuint32)
+  * Given a call AST node: `Call(callee_index: uint32_t, args: AstNode[])`
+    * First write the opcode of `Call` (uint8)
+    * Then write the (variable-length) integer `callee_index` (varuint32)
     * Then recursively write each argument node, where arity is determined by looking up `callee_index` in a table of signatures
 
 ### Strings

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -199,13 +199,41 @@ first byte, before the child nodes.
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
 | `nop` | `0x00` | | no operation |
-| `block` | `0x01` | count = `varuint32` | a sequence of expressions, the last of which yields a value |
-| `loop` | `0x02` | count = `varuint32` | a block which can also form control flow loops |
+| `block` | `0x01` | count = `uint8` | a sequence of expressions, the last of which yields a value |
+| `loop` | `0x02` | count = `uint8` | a block which can also form control flow loops |
 | `if` | `0x03` | | high-level one-armed if |
 | `if_else` | `0x04` | | high-level two-armed if |
 | `select` | `0x05` | | select one of two values based on condition |
 | `br` | `0x06` | relative_depth = `uint8` | break that targets a outer nested block |
 | `br_if` | `0x07` | relative_depth = `uint8` | conditional break that targets a outer nested block |
-| `tableswitch` | 0x08 | `tableswitch_operand` | tableswitch control flow construct |
-| `return` | 0x14 | | return zero or one value from this function |
-| `unreachable` | 0x15 | | trap immediately |
+| `tableswitch` | `0x08` | see below | tableswitch control flow construct |
+| `return` | `0x14` | | return zero or one value from this function |
+| `unreachable` | `0x15` | | trap immediately |
+
+The `tableswitch` operator has as complex immediate operand which is encoded as follows:
+
+| Field | Type | Description |
+| ---- | ---- | ---- |
+| case_count | `uint16` | number of cases in the case_table |
+| target_count | `uint16` | number of targets in the target_table |
+| target_table | `uint16*` | target entries where<br>`>= 0x800` indicates an outer block to which to break<br>`<= 0x8000` indicates a case to which to jump |
+
+The table switch operator is then immediately followed by `case_count` case expressions which by default fall through to each other.
+
+## Basic operators
+| Name | Opcode | Immediate | Description |
+| ---- | ---- | ---- | ---- |
+| `i8.const` | `0x09` | value = `uint8` | a constant value, signed extended to type `i32`  |
+| `i32.const` | `0x0a` | value = `uint32` | a constant value interpreted as `i32` |
+| `i64.const` | `0x0b` | value = `uint64` | a constant value interpreted as `i64` |
+| `f64.const` | `0x0c` | value = `uint64` | a constant value interpreted as `f64` |
+| `f32.const` | `0x0d` | value = `uint32` | a constant value interpreted as `f32` |
+| `get_local` | `0x0e` | local_index = `varuint32` | read a local variable or parameter |
+| `set_local` | `0x0f` | local_index = `varuint32` | write a local variable or parameter |
+| `load_global` | `0x10` | index = `varuint32` | * nonstandard internal opcode |
+| `store_global` | `0x11` | index = `varuint32` | * nonstandard internal opcode |
+| `call_function` | `0x12` | function_index = `varuint32` | call a function by its index |
+| `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
+
+
+

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -226,7 +226,7 @@ The `tableswitch` operator has as complex immediate operand which is encoded as 
 | ---- | ---- | ---- |
 | case_count | `uint16` | number of cases in the case_table |
 | target_count | `uint16` | number of targets in the target_table |
-| target_table | `uint16*` | target entries where<br>`>= 0x8000` indicates an outer block to which to break<br>`<= 0x8000` indicates a case to which to jump |
+| target_table | `uint16*` | target entries where<br>`>= 0x8000` indicates an outer block to which to break<br>`< 0x8000` indicates a case to which to jump |
 
 The table switch operator is then immediately followed by `case_count` case expressions which by default fall through to each other.
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -236,7 +236,7 @@ The table switch operator is then immediately followed by `case_count` case expr
 ## Basic operators ([described here](AstSemantics.md#constants))
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
-| `i8.const` | `0x09` | value = `uint8` | a constant value, signed extended to type `i32`  |
+| `i8.const` | `0x09` | value = `int8` | a constant value, signed extended to type `i32`  |
 | `i32.const` | `0x0a` | value = `uint32` | a constant value interpreted as `i32` |
 | `i64.const` | `0x0b` | value = `uint64` | a constant value interpreted as `i64` |
 | `f64.const` | `0x0c` | value = `uint64` | a constant value interpreted as `f64` |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -125,10 +125,10 @@ must contain a function body. Imported and exported functions must have a name. 
 | flags | `uint8` | always | flags indicating attributes of a function <br>bit `0` : a name is present<br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
 | signature | `uint16` | always | index into the Signature section |
 | name | `uint32` | `flags[0] == 1` | name of the function as an offset within the module |
-| i32 count | `uint16` | `flags[2] == 1` | number of i32 local variables |
-| i64 count | `uint16` | `flags[2] == 1` | number of i64 local variables |
-| f32 count | `uint16` | `flags[2] == 1` | number of f32 local variables |
-| f64 count | `uint16` | `flags[2] == 1` | number of f64 local variables |
+| i32 count | `uint16` | `flags[2] == 1` | number of `i32` local variables |
+| i64 count | `uint16` | `flags[2] == 1` | number of `i64` local variables |
+| f32 count | `uint16` | `flags[2] == 1` | number of `f32` local variables |
+| f64 count | `uint16` | `flags[2] == 1` | number of `f64` local variables |
 | body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
 | body | `bytes` | `flags[0] == 0` | function body |
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -43,6 +43,14 @@ A four-byte little endian unsigned integer.
 ### varuint32
 A [LEB128](https://en.wikipedia.org/wiki/LEB128) variable-length integer, limited to uint32 values.
 
+### value_type
+A single-byte unsigned integer indicating a [value type](AstSemantics.md#types). These types are encoded as:
+* `1` indicating type `i32` 
+* `2` indicating type `i64` 
+* `3` indicating type `f32` 
+* `4` indicating type `f64`
+
+
 # Definitions
 
 ### Pre-order encoding
@@ -95,8 +103,8 @@ A module may contain at most one signatures section.
 | Field | Type | Description |
 | ----- |  ----- | ----- | 
 | param_count | `uint8` | the number of parameters to the function |
-| return_type | `local_type?` | the return type of the function, with `0` indicating no return type |
-| param_types | `local_type*` | the parameter types of the function, with<br>`1` indicating type `i32`<br>`2` indicating type `i64`<br>`3` indicating type `f32`<br>`4` indicating type `f64` |
+| return_type | `value_type?` | the return type of the function, with `0` indicating no return type |
+| param_types | `value_type*` | the parameter types of the function |
 
 ### Functions section
 The Functions section declares the functions in the module and must be preceded by a [Signatures](#signatures-section) section. A module may contain at most one functions section.

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -24,8 +24,10 @@ The encoding is split into three layers:
   to deliver dramatically smaller files.
 
 Most importantly, the layering approach allows development and standardization to
-occur incrementally, even though production-quality implementations will need to
-implement all of the layers.
+occur incrementally. For example, Layer 1 and Layer 2 encoding techniques can be
+experimented with by application-level decompressing to the layer below. As 
+compression techniques  stabilize, they can be standardized and moved into native 
+implementations.
 
 # Data types
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -31,6 +31,9 @@ implementations.
 
 # Data types
 
+### int8
+A single-byte signed integer.
+
 ### uint8
 A single-byte unsigned integer.
 
@@ -201,8 +204,8 @@ stored to from dedicated instructions.
 
 Function bodies consist of a dense pre-order encoding of an [Abstract Syntax Tree](AstSemantics.md).
 Each node in the abstract syntax tree corresponds to an operator, such as `i32.add` or `if` or `block`.
-Most operators encode as a single `uint8`, but some require *immediates* which immediately follow the
-first byte, before the child nodes.
+Operators are encoding by an opcode byte followed by immediate bytes (if any), followed by children 
+nodes (if any).
 
 ## Control flow operators ([described here](AstSemantics.md#control-flow-structures))
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -118,7 +118,7 @@ The Functions section declares the functions in the module and must be preceded 
 #### Function Entry
 
 Each function entry describes a function that can be optionally named, imported and/or exported. Non-imported functions
-must contain a function body.
+must contain a function body. Imported and exported functions must have a name. Imported functions do not contain a body.
 
 | Field | Type |  Present?  | Description |
 | ----- |  ----- |  ----- |  ----- | 


### PR DESCRIPTION
Unfortunately @kg is unable to continue with #520 which updates BinaryEncoding.md to be more in line with the V8 format embodied in the design doc. Unfortunately the branch from which she made the pull request is in her private repo, and I could not edit it. So I started with her changes and made this pull request to continue the discussion.