### PR TITLE
Make `grow_memory` return the old memory size.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -206,7 +206,7 @@ which is 64KiB on all engines (though large page support may be added in
 the [future](FutureFeatures.md#large-page-support)).
 
  * `grow_memory` : grow linear memory by a given unsigned delta which
-    must be a multiple of the page size.
+    must be a multiple of the page size. Return the previous memory size.
 
 As stated [above](AstSemantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the

--- a/Rationale.md
+++ b/Rationale.md
@@ -116,6 +116,14 @@ WebAssembly engines.
 In the future, WebAssembly may offer the ability to use larger page sizes on
 some platforms for increased TLB efficiency.
 
+The `grow_memory` operator returns the old memory size. This is desirable for
+using `grow_memory` independently on multiple threads, so that each thread can
+know where the region it allocated starts. The obvious alternative would be for
+such threads to communicate manually, however wasm implementations will likely
+already be communicating between threads in order to properly allocate the sum
+of the allocation requests, so it's expected that they can provide the needed
+information without significant extra effort.
+
 
 ## Linear memory disabled if no linear memory section
 


### PR DESCRIPTION
This implements the discussion in #525.