### PR TITLE
Add import table.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -104,6 +104,24 @@ A module may contain at most one signatures section.
 | return_type | `value_type?` | the return type of the function, with `0` indicating no return type |
 | param_types | `value_type*` | the parameter types of the function |
 
+### Import table section
+The import section declares all imports that will be used in the module.
+A module may contain at most one import table section.
+
+| Field | Type | Description |
+| ----- |  ----- | ----- | 
+| id = `0x08` | `uint8` | section identifier for imports |
+| count | `varuint32` | count of import entries to follow | 
+| entries | `import_entry*` | repeated import entries as described below |
+
+#### Import entry
+| Field | Type | Description |
+| ----- |  ----- | ----- | 
+| sig_index | `uint16` | signature index of the import |
+| module_name | `uint32` | offset of the string representing the module name |
+| func_name | `uint32` | offset of the string representing the function name |
+
+
 ### Functions section
 The Functions section declares the functions in the module and must be preceded by a [Signatures](#signatures-section) section. A module may contain at most one functions section.
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -118,8 +118,8 @@ A module may contain at most one import table section.
 | Field | Type | Description |
 | ----- |  ----- | ----- | 
 | sig_index | `uint16` | signature index of the import |
-| module_name | `uint32` | offset of the string representing the module name |
-| func_name | `uint32` | offset of the string representing the function name |
+| module_name | `uint32` | offset from the start of the module of the string representing the module name |
+| func_name | `uint32` | offset from the start of the module of the string representing the function name |
 
 
 ### Functions section


### PR DESCRIPTION
Add documentation for the import table section. Like the other sections, for now these entries use `uint32` for string offsets and `uint16` for signature indexes. We should update all offsets and indexes to be `varuint32` in the future, in one bulk update.