### PR TITLE
Fix terminology nit

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -557,7 +557,7 @@ Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operator exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) traps.
 
-## Type-parameterized operators.
+## Type-parametric operators.
 
   * `select`: a ternary operator with two operands, which have the same type as
     each other, plus a boolean (i32) condition. `select` returns the first


### PR DESCRIPTION
"type-parametric" is more accurate than "type-parameterized".