### PR TITLE
Remove the import and export flags from function definitions.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -146,20 +146,18 @@ The Functions section declares the functions in the module and must be preceded 
 
 #### Function Entry
 
-Each function entry describes a function that can be optionally named, imported and/or exported. Non-imported functions
-must contain a function body. Imported and exported functions must have a name. Imported functions do not contain a body.
+Each function entry describes a function.
 
 | Field | Type |  Present?  | Description |
 | ----- |  ----- |  ----- |  ----- |
-| flags | `uint8` | always | flags indicating attributes of a function <br>bit `0` : a name is present<br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
+| flags | `uint8` | always | flags indicating attributes of a function <br>bit `2` : the function has local variables |
 | signature | `uint16` | always | index into the Signature section |
-| name | `uint32` | `flags[0] == 1` | name of the function as an offset within the module |
 | i32 count | `uint16` | `flags[2] == 1` | number of `i32` local variables |
 | i64 count | `uint16` | `flags[2] == 1` | number of `i64` local variables |
 | f32 count | `uint16` | `flags[2] == 1` | number of `f32` local variables |
 | f64 count | `uint16` | `flags[2] == 1` | number of `f64` local variables |
-| body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
-| body | `bytes` | `flags[0] == 0` | function body |
+| body size | `uint16` | always | size of function body to follow, in bytes |
+| body | `bytes` | always | function body |
 
 ### Start Function section
 


### PR DESCRIPTION
Follow up to https://github.com/WebAssembly/design/pull/547

Imports have a separate section now, that also includes the module name. This leaves just exports that need naming here, so the 'named' flag can also be removed. A debug info section is planned for naming the function labels.