### PR TITLE
Note that leading zeros in leb128 values have no semantic effect.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -39,7 +39,7 @@ A two-byte little endian unsigned integer.
 A four-byte little endian unsigned integer.
 
 ### varuint32
-A [LEB128](https://en.wikipedia.org/wiki/LEB128) variable-length integer, limited to uint32 values. `varuint32` values may contain leading zeros.
+A [LEB128](https://en.wikipedia.org/wiki/LEB128) variable-length integer, limited to uint32 values. `varuint32` values may contain leading zeros. Leading zeros in `varuint32` values have no sematic effect and may be canonicalized away by tools or the communication pipeline.
 
 ### value_type
 A single-byte unsigned integer indicating a [value type](AstSemantics.md#types). These types are encoded as:


### PR DESCRIPTION
While this is implict in the current usage of the values, this clause is intended to guard against future specification additions that disguish wasm files based on redundant leading zeros. Also to guard again consumers treating files differently based on such choices. Perhaps also to require canonicalization if hashing for resource integrity.