### PR TITLE
Use a fixed with encoding for sections sizes.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -85,7 +85,7 @@ This is followed by a sequence of sections. Sections can in general be repeated,
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| size  | `varuint32` | size of this section in bytes, excluding this size |
+| size  | `uint32` | size of this section in bytes, excluding this size |
 | id_len | `varuint32` | section identifier string length |
 | id_str | `bytes` | section identifier string of id_len bytes |
 


### PR DESCRIPTION
Here's a suggestion:

The section sizes will often need back-patching to avoid firstly writing to a separate store to determine the size and then copying across. For example, for the functions sections even if the AST sizes are known when encoding (and even if a post-order encoding helps here) it would take another pass to determine the encoded size.

There are only a small number of sections so the file size difference compared to using the leb128 encoding is expected to be small, and this goes some way to avoiding the need for leb128 with redundant leading zeros. It might actually improve the compressed size of a custom compressor as it does not need to encode the leb128 encoding length.

WDYT?