### PR TITLE
Move the function bodies OOL wrt the sections.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -151,6 +151,7 @@ The Functions section declares the functions in the module and must be preceded 
 | ----- |  ----- | ----- |
 | count | `varuint32` | count of function entries to follow |
 | entries | `function_entry*` | repeated function entries as described below |
+| bodies_offset | `uint32` | offset in the file of the start of the function bodies |
 
 #### Function Entry
 
@@ -159,13 +160,20 @@ must contain a function body. Imported and exported functions must have a name. 
 
 | Field | Type |  Present?  | Description |
 | ----- |  ----- |  ----- |  ----- |
-| flags | `uint8` | always | flags indicating attributes of a function <br>bit `0` : a name is present<br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
+| flags | `uint8` | always | flags indicating attributes of a function <br>bit `0` : a name is present<br>bit `1` : the function is an import<br>bit `3` : the function is an export |
 | signature | `uint16` | always | index into the Signature section |
 | name | `uint32` | `flags[0] == 1` | name of the function as an offset within the module |
-| local count | `varuint32` | always | number of local entries |
-| locals | `local_entry*` | always | local variables |
-| body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
-| body | `bytes` | `flags[0] == 0` | function body |
+| body size | `uint16` | `flags[0] == 0` | size of the OOL function body, including the local variable definitions |
+
+#### Function Body Entry.
+
+For each function with `flags[0] == 0` and starting at offset `bodies_offset` there is a function body entry as follows. These follow each other in the same order as the functions were defined in this section.
+
+| Field | Type |  Description |
+| ----- |  ----- | ----- |
+| local count | `varuint32` | number of local entries |
+| locals | `local_entry*` | local variables |
+| body | `bytes` | function body |
 
 #### Local Entry
 


### PR DESCRIPTION
Only the function bodies remain inline in the sections as potential bulk data. With the function bodies moved OOL it might be practical for the runtime to delay compilation until all the section definitions have been read and then to use the section definitions to plan the compilation of the module.

The body sizes have been kept in the section definitions as a suggestion. These would be expected to be back patched and perhaps retain a fixed width encoding. Knowing the function body sizes early might give the runtime compiler a good hint about the resources need to compile each function. For example, it might choose to compile huge functions with only a single compilation thread running if the runtime is memory constrained. Defining the function body sizes is the sections might also give the runtime a map of where each function is defined after reading only the sections definitions - might be good to dispatching multi-threaded processor or for selective view-source or debugging etc.

The local variable definitions have also been moved OOL as a suggestion. These might not be known when building the sections and having them OOL might avoid back patching their definition into the sections which would become more problematic with the new layout for these.