### PR TITLE
Names section

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -165,9 +165,8 @@ must contain a function body. Imported and exported functions must have a name. 
 
 | Field | Type |  Present?  | Description |
 | ----- |  ----- |  ----- |  ----- |
-| flags | `uint8` | always | flags indicating attributes of a function <br>bit `0` : a name is present<br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
+| flags | `uint8` | always | flags indicating attributes of a function <br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
 | signature | `uint16` | always | index into the Signature section |
-| name | `uint32` | `flags[0] == 1` | name of the function as an offset within the module |
 | body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
 | body | `bytes` | `flags[0] == 0` | function body |
 
@@ -233,6 +232,42 @@ This section must be preceded by a [Functions](#functions-section) section.
 | ----- |  ----- | ----- |
 | count | `varuint32` | count of entries to follow |
 | entries | `uint16*` | repeated indexes into the function table |
+
+### Function Names section
+
+ID: `function_names`
+
+| Field | Type | Description |
+| ----- |  ----- | ----- |
+| names | `utf8-C-string*` | sequence of null-terminated utf8-encoded strings |
+
+The number of names is determined by the number of declared functions. The
+sequence of names assigns a name to each function index.
+
+This section is optional and does not contribute to the semenatics of execution.
+A validation error in this section is not reported and is treated as the section
+being absent. The expectation is that, when a binary WebAssembly module is
+viewed in a browser or other development environment, the names in this section
+will be used as the names of functions in the [text format](TextFormat.md).
+
+### Local Names section
+
+ID: `local_names`
+
+| Field | Type | Description |
+| ----- |  ----- | ----- |
+| names | `utf8-C-string*` | sequence of null-terminated utf8-encoded strings |
+
+The number of names is determined by the sum of all functions' number of locals.
+The sequence of names is defined to be the concatentation of the sequence of
+local names (ordered by local index) for each function (ordered by function index).
+This sequence assigns a name to every local index in every function.
+
+This section is optional and does not contribute to the semenatics of execution.
+A validation error in this section is not reported and is treated as the section
+being absent. The expectation is that, when a binary WebAssembly module is
+viewed in a browser or other development environment, the names in this section
+will be used as the names of locals in the [text format](TextFormat.md).
 
 ### End section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -244,8 +244,8 @@ ID: `function_names`
 The number of names is determined by the number of declared functions. The
 sequence of names assigns a name to each function index.
 
-This section is optional and does not contribute to the semenatics of execution.
-A validation error in this section is not reported and is treated as the section
+This section may occur 0 or 1 times and does not change observable semantics. A
+validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section
 will be used as the names of functions in the [text format](TextFormat.md).
@@ -263,8 +263,8 @@ The sequence of names is defined to be the concatentation of the sequence of
 local names (ordered by local index) for each function (ordered by function index).
 This sequence assigns a name to every local index in every function.
 
-This section is optional and does not contribute to the semenatics of execution.
-A validation error in this section is not reported and is treated as the section
+This section may occur 0 or 1 times and does not change observable semantics. A
+validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section
 will be used as the names of locals in the [text format](TextFormat.md).

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -235,39 +235,49 @@ This section must be preceded by a [Functions](#functions-section) section.
 
 ### Function Names section
 
-ID: `function_names`
-
-| Field | Type | Description |
-| ----- |  ----- | ----- |
-| names | `utf8-C-string*` | sequence of null-terminated utf8-encoded strings |
-
-The number of names is determined by the number of declared functions. The
-sequence of names assigns a name to each function index.
-
 This section may occur 0 or 1 times and does not change execution semantics. A
 validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section
 will be used as the names of functions in the [text format](TextFormat.md).
 
-### Local Names section
-
-ID: `local_names`
+ID: `function_names`
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| names | `utf8-C-string*` | sequence of null-terminated utf8-encoded strings |
+| names | `name*` | sequence of names |
 
-The number of names is determined by the sum of all functions' number of locals.
-The sequence of names is defined to be the concatentation of the sequence of
-local names (ordered by local index) for each function (ordered by function index).
-This sequence assigns a name to every local index in every function.
+The number of names is determined by the number of declared functions. The
+sequence of names assigns a name to each function index. A name is:
+
+| Field | Type | Description |
+| ----- |  ----- | ----- |
+| size | varuint32 | string length, in bytes |
+| string | bytes | valid utf8-encoding of non-null code points |
+
+### Local Names section
 
 This section may occur 0 or 1 times and does not change execution semantics. A
 validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section
 will be used as the names of locals in the [text format](TextFormat.md).
+
+ID: `local_names`
+
+| Field | Type | Description |
+| ----- |  ----- | ----- |
+| names | `name*` | sequence of names |
+
+The number of names is determined by the sum of all functions' number of locals.
+The sequence of names is defined to be the concatentation of the sequence of
+local names (ordered by local index) for each function (ordered by function index).
+This sequence assigns a name to every local index in every function. A name is:
+
+| Field | Type | Description |
+| ----- |  ----- | ----- |
+| size | varuint32 | string length, in bytes |
+| string | bytes | valid utf8-encoding of non-null code points |
 
 ### End section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -263,7 +263,7 @@ functions.
 | local_names | `local_name*` | sequence of local names |
 
 The sequence of `local_name` assigns names to the corresponding local index. The
-count may be greater or less than the actual number of functions.
+count may be greater or less than the actual number of locals.
 
 #### Local name
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -246,8 +246,8 @@ functions and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| count | `varuint32` | count of names to follow |
-| names | `function_names*` | sequence of names |
+| count | `varuint32` | count of entries to follow |
+| entries | `function_names*` | sequence of names |
 
 The sequence of `function_name` assigns names to the corresponding
 function index. The count may be greater or less than the actual number of

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -233,51 +233,44 @@ This section must be preceded by a [Functions](#functions-section) section.
 | count | `varuint32` | count of entries to follow |
 | entries | `uint16*` | repeated indexes into the function table |
 
-### Function Names section
+### Names section
+
+ID: `names`
 
 This section may occur 0 or 1 times and does not change execution semantics. A
-validation error in this section is not reported and is treated as the section
-being absent. The expectation is that, when a binary WebAssembly module is
-viewed in a browser or other development environment, the names in this section
-will be used as the names of functions in the [text format](TextFormat.md).
-
-ID: `function_names`
-
-| Field | Type | Description |
-| ----- |  ----- | ----- |
-| names | `name*` | sequence of names |
-
-The number of names is determined by the number of declared functions. The
-sequence of names assigns a name to each function index. A name is:
+validation error in this section does not cause validation for the whole module
+to fail and is instead treated as if the section was absent. The expectation is
+that, when a binary WebAssembly module is viewed in a browser or other
+development environment, the names in this section will be used as the names of
+functions and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| size | varuint32 | string length, in bytes |
-| string | bytes | valid utf8 encoding |
+| count | `varuint32` | count of names to follow |
+| names | `function_names*` | sequence of names |
 
-### Local Names section
+The sequence of `function_name` assigns names to the corresponding
+function index. The count may be greater or less than the actual number of
+functions.
 
-This section may occur 0 or 1 times and does not change execution semantics. A
-validation error in this section is not reported and is treated as the section
-being absent. The expectation is that, when a binary WebAssembly module is
-viewed in a browser or other development environment, the names in this section
-will be used as the names of locals in the [text format](TextFormat.md).
-
-ID: `local_names`
+#### Function names
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| names | `name*` | sequence of names |
+| fun_name_len | `varuint32` | string length, in bytes |
+| fun_name_str | `bytes` | valid utf8 encoding |
+| local_count | `varuint32` | count of local names to follow |
+| local_names | `local_name*` | sequence of local names |
 
-The number of names is determined by the sum of all functions' number of locals.
-The sequence of names is defined to be the concatentation of the sequence of
-local names (ordered by local index) for each function (ordered by function index).
-This sequence assigns a name to every local index in every function. A name is:
+The sequence of `local_name` assigns names to the corresponding local index. The
+count may be greater or less than the actual number of functions.
+
+#### Local name
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| size | varuint32 | string length, in bytes |
-| string | bytes | valid utf8 encoding |
+| local_name_len | `varuint32` | string length, in bytes |
+| local_name_str | `bytes` | valid utf8 encoding |
 
 ### End section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -253,7 +253,7 @@ sequence of names assigns a name to each function index. A name is:
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | size | varuint32 | string length, in bytes |
-| string | bytes | valid utf8-encoding of non-null code points |
+| string | bytes | valid utf8 encoding |
 
 ### Local Names section
 
@@ -277,7 +277,7 @@ This sequence assigns a name to every local index in every function. A name is:
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | size | varuint32 | string length, in bytes |
-| string | bytes | valid utf8-encoding of non-null code points |
+| string | bytes | valid utf8 encoding |
 
 ### End section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -244,7 +244,7 @@ ID: `function_names`
 The number of names is determined by the number of declared functions. The
 sequence of names assigns a name to each function index.
 
-This section may occur 0 or 1 times and does not change observable semantics. A
+This section may occur 0 or 1 times and does not change execution semantics. A
 validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section
@@ -263,7 +263,7 @@ The sequence of names is defined to be the concatentation of the sequence of
 local names (ordered by local index) for each function (ordered by function index).
 This sequence assigns a name to every local index in every function.
 
-This section may occur 0 or 1 times and does not change observable semantics. A
+This section may occur 0 or 1 times and does not change execution semantics. A
 validation error in this section is not reported and is treated as the section
 being absent. The expectation is that, when a binary WebAssembly module is
 viewed in a browser or other development environment, the names in this section


### PR DESCRIPTION
This PR adds two optional sections: one containing a sequence of names of functions and one containing a sequence of names of locals.  The goal is that, when present, these names are used instead of auto-generated names in any projected text and so this constitutes the wasm analogue of a "symbol section".  Locals are separate since they'll be a lot bigger and devs may want function names but not locals.  Later, we could consider alternative sections which instead contain only a URL but I think in the MVP it'll be much simpler to embed these in the module file.

A few choices which I thought about a bit but could be convinced otherwise on:

. Unlike exports/imports which we wanted to leave as unconstrained byte sequence, if the *entire purpose* of these names is to be displayed as text in the text format, then it seems justified to constrain them to be valid utf8-encoded, null-terminated strings.  Note that an engine doesn't have to validate or even look at this section if it doesn't want to, so it doesn't force utf8 decoding.  Also, even if we didn't constrain the byte sequence, I think we'd end up with this limitation in practice.  We could consider giving each string a preceding byte length for symmetry with export/import strings, but I think this would simply add validation work without benefit.

. These name sections don't declare the number of functions or number of locals, they instead implicitly refer to the already-declared number-of-functions/locals.  We could add lengths but, as above, I think this would just add work without benefit.