### PR TITLE
Add a call_import opcode

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -314,7 +314,7 @@ The table switch operator is then immediately followed by `case_count` case expr
 | `set_local` | `0x0f` | local_index = `varuint32` | write a local variable or parameter |
 | `load_global` | `0x10` | index = `varuint32` | * nonstandard internal opcode |
 | `store_global` | `0x11` | index = `varuint32` | * nonstandard internal opcode |
-| `call_function` | `0x12` | function_index = `varuint32` | call a function by its index |
+| `call` | `0x12` | function_index = `varuint32` | call a function by its index |
 | `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
 | `call_import` | `0x09` | import_index = `varuint32` | call an imported function by its index |
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -316,6 +316,7 @@ The table switch operator is then immediately followed by `case_count` case expr
 | `store_global` | `0x11` | index = `varuint32` | * nonstandard internal opcode |
 | `call_function` | `0x12` | function_index = `varuint32` | call a function by its index |
 | `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
+| `call_import` | `0x09` | import_index = `varuint32` | call an imported function by its index |
 
 ## Memory-related operators ([described here](AstSemantics.md#linear-memory-accesses))
 


### PR DESCRIPTION
BinaryFormat.md was lacking an opcode value for call_import. This PR adds one, and defines an encoding for it.