### PR TITLE
Split Functions section into Function Signatures and Function Bodies

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -145,28 +145,31 @@ A module may contain at most one import table section.
 | function_len | `varuint32` | function string length |
 | function_str | `bytes` | function string of `function_len` bytes |
 
-### Functions section
+### Function Signatures section
 
-ID: `functions`
+ID: `function_signatures`
 
-The Functions section declares the functions in the module and must be preceded by a [Signatures](#signatures-section) section. A module may contain at most one functions section.
+The Functions Signatures section declares the signatures of all functions in the
+module and must be preceded by the [Signatures](#signatures-section) section. A
+module may contain at most one functions section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| count | `varuint32` | count of function entries to follow |
-| entries | `function_entry*` | repeated function entries as described below |
+| count | `varuint32` | count of signature indices to follow |
+| signatures | `varuint32*` | sequence of indices into the Signature section |
 
-#### Function Entry
+### Function Bodies section
 
-Each function entry describes a function that can be optionally named, imported and/or exported. Non-imported functions
-must contain a function body. Imported and exported functions must have a name. Imported functions do not contain a body.
+ID: `function_bodies`
 
-| Field | Type |  Present?  | Description |
+The Function Bodies section assigns a body to every function in the module and
+must be preceded by the [Function Signatures](#function-signatures-section) section.
+The count of function signatures and function bodies must be the same.
+
+| Field | Type |  Description |
 | ----- |  ----- |  ----- |  ----- |
-| flags | `uint8` | always | flags indicating attributes of a function <br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
-| signature | `uint16` | always | index into the Signature section |
-| body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
-| body | `bytes` | `flags[0] == 0` | function body |
+| count | `varuint32` | count of function bodies to follow |
+| bodies | `function_body*` | sequence of [Function Bodies](#function-bodies) |
 
 ### Export Table section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -187,7 +187,6 @@ This section must be preceded by a [Functions](#functions-section) section.
 #### Export entry
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| sig_index | `uint16` | signature index of the export |
 | func_index | `uint16` | index into the function table |
 | function_len | `varuint32` | function string length |
 | function_str | `bytes` | function string of `function_len` bytes |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -303,6 +303,7 @@ nodes (if any).
 
 | Name | Opcode |Description |
 | ----- | ----- | ----- |
+| body size | `varuint32` | size of function body to follow, in bytes |
 | local count | `varuint32` | number of local entries |
 | locals | `local_entry*` | local variables |
 | ast    | `byte*` | pre-order encoded AST |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -178,7 +178,7 @@ ID: `export_table`
 
 The export table section declares all exports from the module.
 A module may contain at most one export table section.
-This section must be preceded by a [Functions](#functions-section) section.
+This section must be preceded by the [Function Signatures](#function-signatures-section) section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -197,7 +197,7 @@ This section must be preceded by a [Functions](#functions-section) section.
 ID: `start_function`
 
 A module may contain at most one start fuction section.
-This section must be preceded by a [Functions](#functions-section) section.
+This section must be preceded by a [Function Signatures](#function-signatures-section) section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -228,8 +228,7 @@ a `data_segment` is:
 ID: `function_table`
 
 The indirect function table section declares the size and entries of the indirect function table, which consist
-of indexes into the [Functions](#functions-section) section.
-This section must be preceded by a [Functions](#functions-section) section.
+of indexes into the [Function Signatures](#function-signatures-section) section (which must come before).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -149,9 +149,9 @@ A module may contain at most one import table section.
 
 ID: `function_signatures`
 
-The Functions Signatures section declares the signatures of all functions in the
+The Function Signatures section declares the signatures of all functions in the
 module and must be preceded by the [Signatures](#signatures-section) section. A
-module may contain at most one functions section.
+module may contain at most one functions signatures section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -164,7 +164,8 @@ ID: `function_bodies`
 
 The Function Bodies section assigns a body to every function in the module and
 must be preceded by the [Function Signatures](#function-signatures-section) section.
-The count of function signatures and function bodies must be the same.
+The count of function signatures and function bodies must be the same and the `i`th
+signature corresponds to the `i`th function body.
 
 | Field | Type |  Description |
 | ----- |  ----- |  ----- |  ----- |


### PR DESCRIPTION
This PR splits the Functions section into a Function Signatures section that goes near the beginning of the module and a Function Bodies section that would go at the end (but before Data Segments and Names).  This allows all function signatures to be known when compiling function bodies.