### PR TITLE
Convert (most) remaining fixed-width immediates to LEB128

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -145,28 +145,31 @@ A module may contain at most one import table section.
 | function_len | `varuint32` | function string length |
 | function_str | `bytes` | function string of `function_len` bytes |
 
-### Functions section
+### Function Signatures section
 
-ID: `functions`
+ID: `function_signatures`
 
-The Functions section declares the functions in the module and must be preceded by a [Signatures](#signatures-section) section. A module may contain at most one functions section.
+The Functions Signatures section declares the signatures of all functions in the
+module and must be preceded by the [Signatures](#signatures-section) section. A
+module may contain at most one functions section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| count | `varuint32` | count of function entries to follow |
-| entries | `function_entry*` | repeated function entries as described below |
+| count | `varuint32` | count of signature indices to follow |
+| signatures | `varuint32*` | sequence of indices into the Signature section |
 
-#### Function Entry
+### Function Bodies section
 
-Each function entry describes a function that can be optionally named, imported and/or exported. Non-imported functions
-must contain a function body. Imported and exported functions must have a name. Imported functions do not contain a body.
+ID: `function_bodies`
 
-| Field | Type |  Present?  | Description |
+The Function Bodies section assigns a body to every function in the module and
+must be preceded by the [Function Signatures](#function-signatures-section) section.
+The count of function signatures and function bodies must be the same.
+
+| Field | Type |  Description |
 | ----- |  ----- |  ----- |  ----- |
-| flags | `uint8` | always | flags indicating attributes of a function <br>bit `1` : the function is an import<br>bit `2` : the function has local variables<br>bit `3` : the function is an export |
-| signature | `uint16` | always | index into the Signature section |
-| body size | `uint16` | `flags[0] == 0` | size of function body to follow, in bytes |
-| body | `bytes` | `flags[0] == 0` | function body |
+| count | `varuint32` | count of function bodies to follow |
+| bodies | `function_body*` | sequence of [Function Bodies](#function-bodies) |
 
 ### Export Table section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -187,7 +187,6 @@ This section must be preceded by a [Functions](#functions-section) section.
 #### Export entry
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| sig_index | `uint16` | signature index of the export |
 | func_index | `uint16` | index into the function table |
 | function_len | `varuint32` | function string length |
 | function_str | `bytes` | function string of `function_len` bytes |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -303,6 +303,7 @@ nodes (if any).
 
 | Name | Opcode |Description |
 | ----- | ----- | ----- |
+| body size | `varuint32` | size of function body to follow, in bytes |
 | local count | `varuint32` | number of local entries |
 | locals | `local_entry*` | local variables |
 | ast    | `byte*` | pre-order encoded AST |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -178,7 +178,7 @@ ID: `export_table`
 
 The export table section declares all exports from the module.
 A module may contain at most one export table section.
-This section must be preceded by a [Functions](#functions-section) section.
+This section must be preceded by the [Function Signatures](#function-signatures-section) section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -197,7 +197,7 @@ This section must be preceded by a [Functions](#functions-section) section.
 ID: `start_function`
 
 A module may contain at most one start fuction section.
-This section must be preceded by a [Functions](#functions-section) section.
+This section must be preceded by a [Function Signatures](#function-signatures-section) section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -228,8 +228,7 @@ a `data_segment` is:
 ID: `function_table`
 
 The indirect function table section declares the size and entries of the indirect function table, which consist
-of indexes into the [Functions](#functions-section) section.
-This section must be preceded by a [Functions](#functions-section) section.
+of indexes into the [Function Signatures](#function-signatures-section) section (which must come before).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -26,14 +26,8 @@ implementations.
 
 # Data types
 
-### int8
-A single-byte signed integer.
-
 ### uint8
 A single-byte unsigned integer.
-
-### uint16
-A two-byte little endian unsigned integer.
 
 ### uint32
 A four-byte little endian unsigned integer.
@@ -120,7 +114,7 @@ A module may contain at most one signatures section.
 #### Signature entry
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| param_count | `uint8` | the number of parameters to the function |
+| param_count | `varuint32` | the number of parameters to the function |
 | return_type | `value_type?` | the return type of the function, with `0` indicating no return type |
 | param_types | `value_type*` | the parameter types of the function |
 
@@ -139,7 +133,7 @@ A module may contain at most one import table section.
 #### Import entry
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| sig_index | `uint16` | signature index of the import |
+| sig_index | `varuint32` | signature index of the import |
 | module_len | `varuint32` | module string length |
 | module_str | `bytes` | module string of `module_len` bytes |
 | function_len | `varuint32` | function string length |
@@ -188,7 +182,7 @@ This section must be preceded by the [Function Signatures](#function-signatures-
 #### Export entry
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| func_index | `uint16` | index into the function table |
+| func_index | `varuint32` | index into the function table |
 | function_len | `varuint32` | function string length |
 | function_str | `bytes` | function string of `function_len` bytes |
 
@@ -219,9 +213,9 @@ a `data_segment` is:
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| offset | `uint32` | the offset in linear memory at which to store the data |
-| size | `uint32` | the size of the data segment (in bytes) |
-| data | `bytes` | a sequence of `size` bytes |
+| offset | `varuint32` | the offset in linear memory at which to store the data |
+| size | `uint32` | size of `data` (in bytes) |
+| data | `bytes` | sequence of `size` bytes |
 
 ### Indirect Function Table section
 
@@ -233,7 +227,7 @@ of indexes into the [Function Signatures](#function-signatures-section) section 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | count | `varuint32` | count of entries to follow |
-| entries | `uint16*` | repeated indexes into the function table |
+| entries | `varuint32*` | repeated indexes into the function table |
 
 ### Names section
 
@@ -288,7 +282,7 @@ by the decoder. It can used, for example, to store function names or data segmen
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| body  | `bytes`     | contents of this section |
+| body  | `bytes` | contents of this section |
 
 Sections whose ID is unknown to the WebAssembly implementation are ignored.
 
@@ -323,13 +317,13 @@ It is legal to have several entries with the same type.
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
 | `nop` | `0x00` | | no operation |
-| `block` | `0x01` | count = `uint8` | a sequence of expressions, the last of which yields a value |
-| `loop` | `0x02` | count = `uint8` | a block which can also form control flow loops |
+| `block` | `0x01` | count = `varuint32` | a sequence of expressions, the last of which yields a value |
+| `loop` | `0x02` | count = `varuint32` | a block which can also form control flow loops |
 | `if` | `0x03` | | high-level one-armed if |
 | `if_else` | `0x04` | | high-level two-armed if |
 | `select` | `0x05` | | select one of two values based on condition |
-| `br` | `0x06` | relative_depth = `uint8` | break that targets a outer nested block |
-| `br_if` | `0x07` | relative_depth = `uint8` | conditional break that targets a outer nested block |
+| `br` | `0x06` | relative_depth = `varuint32` | break that targets a outer nested block |
+| `br_if` | `0x07` | relative_depth = `varuint32` | conditional break that targets a outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
 | `return` | `0x14` | | return zero or one value from this function |
 | `unreachable` | `0x15` | | trap immediately |
@@ -338,9 +332,9 @@ The `br_table` operator has an immediate operand which is encoded as follows:
 
 | Field | Type | Description |
 | ---- | ---- | ---- |
-| target_count | `uint16` | number of targets in the target_table |
-| target_table | `uint16*` | target entries that indicate an outer block or loop to which to break |
-| default_target | `uint16` | an outer block or loop to which to break in the default case |
+| target_count | `varuint32` | number of targets in the target_table |
+| target_table | `varuint32*` | target entries that indicate an outer block or loop to which to break |
+| default_target | `varuint32` | an outer block or loop to which to break in the default case |
 
 The `br_table` operator implements an indirect branch. It accepts one `i32` expression as input and 
 branches to the block or loop at the given offset within the `target_table`. If the input value is 
@@ -391,10 +385,10 @@ out of range, `br_table` branches to the default target.
 
 The `memory_immediate` type is encoded as follows:
 
-| Name | Type | Present? | Description |
-| ---- | ---- | ---- | ---- |
-| flags | `uint8` | always | a bitfield where<br>bit `4` indicates an offset follows<br>bit `7` indicates natural alignment<br>other bits are reserved for future use |
-| offset | `varuint32` | `flags[4] == 1` | the value of the offset |
+| Name | Type | Description |
+| ---- | ---- | ---- |
+| offset | `varuint32` | the value of the offset |
+| alignment | `varuint32` | the value of the alignment |
 
 ## Simple operators ([described here](AstSemantics#32-bit-integer-operators))
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -387,8 +387,8 @@ The `memory_immediate` type is encoded as follows:
 
 | Name | Type | Description |
 | ---- | ---- | ---- |
+| flags | `varuint32` | a bitfield currently only containing the alignment (less-or-equal than natural alignment, specified as a power of 2) for the `log2(access size)` least-significant bits |
 | offset | `varuint32` | the value of the offset |
-| alignment | `varuint32` | the value of the alignment |
 
 ## Simple operators ([described here](AstSemantics#32-bit-integer-operators))
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -57,12 +57,12 @@ sequence, then followed recursively by any child nodes.
 
 * Examples
   * Given a simple AST node: `I32Add(left: AstNode, right: AstNode)`
-    * First write the opcode for `I32Add` (`varuint32`)
+    * First write the opcode for `I32Add` (uint8)
     * Then recursively write the left and right nodes.
 
   * Given a call AST node: `Call(callee_index: uint32_t, args: AstNode[])`
-    * First write the opcode of `Call` (`varuint32`)
-    * Then write the (variable-length) integer `callee_index` (`varuint32`)
+    * First write the opcode of `Call` (uint8)
+    * Then write the (variable-length) integer `callee_index` (varuint32)
     * Then recursively write each argument node, where arity is determined by looking up `callee_index` in a table of signatures
 
 # Module structure

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -57,12 +57,12 @@ sequence, then followed recursively by any child nodes.
 
 * Examples
   * Given a simple AST node: `I32Add(left: AstNode, right: AstNode)`
-    * First write the opcode for `I32Add` (uint8)
+    * First write the opcode for `I32Add` (`varuint32`)
     * Then recursively write the left and right nodes.
 
   * Given a call AST node: `Call(callee_index: uint32_t, args: AstNode[])`
-    * First write the opcode of `Call` (uint8)
-    * Then write the (variable-length) integer `callee_index` (varuint32)
+    * First write the opcode of `Call` (`varuint32`)
+    * Then write the (variable-length) integer `callee_index` (`varuint32`)
     * Then recursively write each argument node, where arity is determined by looking up `callee_index` in a table of signatures
 
 # Module structure

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -149,9 +149,9 @@ A module may contain at most one import table section.
 
 ID: `function_signatures`
 
-The Functions Signatures section declares the signatures of all functions in the
+The Function Signatures section declares the signatures of all functions in the
 module and must be preceded by the [Signatures](#signatures-section) section. A
-module may contain at most one functions section.
+module may contain at most one functions signatures section.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -164,7 +164,8 @@ ID: `function_bodies`
 
 The Function Bodies section assigns a body to every function in the module and
 must be preceded by the [Function Signatures](#function-signatures-section) section.
-The count of function signatures and function bodies must be the same.
+The count of function signatures and function bodies must be the same and the `i`th
+signature corresponds to the `i`th function body.
 
 | Field | Type |  Description |
 | ----- |  ----- |  ----- |  ----- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -214,7 +214,7 @@ a `data_segment` is:
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | offset | `varuint32` | the offset in linear memory at which to store the data |
-| size | `uint32` | size of `data` (in bytes) |
+| size | `varuint32` | size of `data` (in bytes) |
 | data | `bytes` | sequence of `size` bytes |
 
 ### Indirect Function Table section

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -333,8 +333,8 @@ The `br_table` operator has an immediate operand which is encoded as follows:
 | Field | Type | Description |
 | ---- | ---- | ---- |
 | target_count | `varuint32` | number of targets in the target_table |
-| target_table | `varuint32*` | target entries that indicate an outer block or loop to which to break |
-| default_target | `varuint32` | an outer block or loop to which to break in the default case |
+| target_table | `uint32*` | target entries that indicate an outer block or loop to which to break |
+| default_target | `uint32` | an outer block or loop to which to break in the default case |
 
 The `br_table` operator implements an indirect branch. It accepts one `i32` expression as input and 
 branches to the block or loop at the given offset within the `target_table`. If the input value is 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -387,8 +387,14 @@ The `memory_immediate` type is encoded as follows:
 
 | Name | Type | Description |
 | ---- | ---- | ---- |
-| flags | `varuint32` | a bitfield currently only containing the alignment (less-or-equal than natural alignment, specified as a power of 2) for the `log2(access size)` least-significant bits |
+| flags | `varuint32` | a bitfield which currently contains the alignment in the least significant bits, encoded as `log2(alignment)` |
 | offset | `varuint32` | the value of the offset |
+
+As implied by the `log2(alignment)` encoding, the alignment must be a power of 2.
+As an additional validation criteria, the alignment must be less or equal to 
+natural alignment. Thus, for any given memory access op, the bits after the
+`log(memory-access-size)` least-significant bits can be used in the future
+(e.g., for shared memory ordering requirements).
 
 ## Simple operators ([described here](AstSemantics#32-bit-integer-operators))
 


### PR DESCRIPTION
This PR builds on previous ones so it's probably best to just look at the last commit.  After the PR, the only fixed-width integers are the magic/version words (kept for simplicity and since they are "special") and the `exported` `uint8` in the Memory section, since it should be going away in a future PR to export (and import) memory from the exports/imports section.