### PR TITLE
Add explicit arities to calls, breaks, & return

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -317,24 +317,26 @@ It is legal to have several entries with the same type.
 
 ## Control flow operators ([described here](AstSemantics.md#control-flow-structures))
 
-| Name | Opcode | Immediate | Description |
+| Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
 | `nop` | `0x00` | | no operation |
-| `block` | `0x01` | count = `uint8` | a sequence of expressions, the last of which yields a value |
-| `loop` | `0x02` | count = `uint8` | a block which can also form control flow loops |
+| `block` | `0x01` | count : `uint8` | a sequence of expressions, the last of which yields a value |
+| `loop` | `0x02` | count : `uint8` | a block which can also form control flow loops |
 | `if` | `0x03` | | high-level one-armed if |
 | `if_else` | `0x04` | | high-level two-armed if |
 | `select` | `0x05` | | select one of two values based on condition |
-| `br` | `0x06` | relative_depth = `uint8` | break that targets a outer nested block |
-| `br_if` | `0x07` | relative_depth = `uint8` | conditional break that targets a outer nested block |
+| `br` | `0x06` | arity : `varuint32`, relative_depth : `uint8` | break that targets a outer nested block |
+| `br_if` | `0x07` | arity : `varuint32`, relative_depth : `uint8` | conditional break that targets a outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
-| `return` | `0x14` | | return zero or one value from this function |
+| `return` | `0x14` | arity : `varuint32` | return zero or one value from this function |
 | `unreachable` | `0x15` | | trap immediately |
 
+All arities must be either 0 or 1 in the MVP.
 The `br_table` operator has an immediate operand which is encoded as follows:
 
 | Field | Type | Description |
 | ---- | ---- | ---- |
+| arity | `varuint32` | number of transfer arguments (0 or 1) |
 | target_count | `uint16` | number of targets in the target_table |
 | target_table | `uint16*` | target entries that indicate an outer block or loop to which to break |
 | default_target | `uint16` | an outer block or loop to which to break in the default case |
@@ -344,19 +346,22 @@ branches to the block or loop at the given offset within the `target_table`. If 
 out of range, `br_table` branches to the default target.
 
 ## Basic operators ([described here](AstSemantics.md#constants))
-| Name | Opcode | Immediate | Description |
+
+| Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
-| `i32.const` | `0x0a` | value = `varint32` | a constant value interpreted as `i32` |
-| `i64.const` | `0x0b` | value = `varint64` | a constant value interpreted as `i64` |
-| `f64.const` | `0x0c` | value = `uint64` | a constant value interpreted as `f64` |
-| `f32.const` | `0x0d` | value = `uint32` | a constant value interpreted as `f32` |
-| `get_local` | `0x0e` | local_index = `varuint32` | read a local variable or parameter |
-| `set_local` | `0x0f` | local_index = `varuint32` | write a local variable or parameter |
-| `load_global` | `0x10` | index = `varuint32` | * nonstandard internal opcode |
-| `store_global` | `0x11` | index = `varuint32` | * nonstandard internal opcode |
-| `call` | `0x12` | function_index = `varuint32` | call a function by its index |
-| `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
-| `call_import` | `0x1f` | import_index = `varuint32` | call an imported function by its index |
+| `i32.const` | `0x0a` | value : `varint32` | a constant value interpreted as `i32` |
+| `i64.const` | `0x0b` | value : `varint64` | a constant value interpreted as `i64` |
+| `f64.const` | `0x0c` | value : `uint64` | a constant value interpreted as `f64` |
+| `f32.const` | `0x0d` | value : `uint32` | a constant value interpreted as `f32` |
+| `get_local` | `0x0e` | local_index : `varuint32` | read a local variable or parameter |
+| `set_local` | `0x0f` | local_index : `varuint32` | write a local variable or parameter |
+| `load_global` | `0x10` | index : `varuint32` | * nonstandard internal opcode |
+| `store_global` | `0x11` | index : `varuint32` | * nonstandard internal opcode |
+| `call` | `0x12` | arity : `varuint32`, function_index : `varuint32` | call a function by its index |
+| `call_indirect` | `0x13` | arity : `varuint32`, signature_index : `varuint32` | call a function indirect with an expected signature |
+| `call_import` | `0x1f` | arity : `varuint32`, import_index : `varuint32` | call an imported function by its index |
+
+The arity immediates for the different call opcodes give the number of arguments.
 
 ## Memory-related operators ([described here](AstSemantics.md#linear-memory-accesses))
 


### PR DESCRIPTION
(And while here, do a stylistic tweak to use `:` for type annotations :) )