### PR TITLE
Define precise order of sections

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -89,10 +89,8 @@ for all sections. The encoding of all sections begins as follows:
 | id_len | `varuint32` | section identifier string length |
 | id_str | `bytes` | section identifier string of id_len bytes |
 
-Each section other than the End section is optional and may appear at most once.
-The End section must appear exactly once. If present, sections must occur in
-this precise order (interleaved or followed by unknown sections, as noted
-above):
+Each section is optional and may appear at most once.
+Known sections (from this list) may not appear out of order.
 
 * [Signatures](#signatures-section) section
 * [Import Table](#import-table-section) section
@@ -103,10 +101,7 @@ above):
 * [Start Function](#start-function-section) section
 * [Function Bodies](#function-bodies-section) section
 * [Data Segments](#data-segments-section) section
-* [End](#end-section) section
 * [Names](#names-section) section
-
-Known sections (from this list) may not appear out of order.
 
 The end of the last present section must coincide with the last byte of the
 module. The shortest valid module is 8 bytes (`magic number`, `version`,
@@ -247,17 +242,6 @@ a `data_segment` is:
 | offset | `varuint32` | the offset in linear memory at which to store the data |
 | size | `varuint32` | size of `data` (in bytes) |
 | data | `bytes` | sequence of `size` bytes |
-
-### End section
-
-ID: `end`
-
-This section is mandatory and indicates the end of the sections that affect
-semantics. Subsequent sections may be skipped or streamed lazily without
-affecting execution.
-
-| Field | Type | Description |
-| ----- |  ----- | ----- |
 
 ### Names section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -89,9 +89,10 @@ for all sections. The encoding of all sections begins as follows:
 | id_len | `varuint32` | section identifier string length |
 | id_str | `bytes` | section identifier string of id_len bytes |
 
-Each section other than the End section is optional and may appear at most once
-and only in the precise order defined below (out-of-order sections are a
-validation error).
+Each section other than the End section is optional and may appear at most once.
+The End section must appear exactly once. If present, sections must occur in
+this precise order (interleaved or followed by unknown sections, as noted
+above):
 
 * [Signatures](#signatures-section) section
 * [Import Table](#import-table-section) section
@@ -105,13 +106,12 @@ validation error).
 * [End](#end-section) section
 * [Names](#names-section) section
 
-The End section must appear exactly once and is the last section that affects
-execution, including whether the module validates. Any validation error after
-the End section causes the containing section and all subsequent bytes to be
-ignored.
+Thus, the shortest valid module is 13 bytes (`magic number`, `version`,
+`size` = 4, `id_len` = 3, `id_str` = "end").
 
-The shortest valid module is thus 13 bytes: `magic number`, `version`,
-`size` = `4`, `id_len` = `3`, `id_str` = `end`.
+Additionally, known sections (from the above list) may not appear out of order
+and the end of the last present section must coincide with the last byte of the
+module. 
 
 ### Signatures section
 
@@ -264,9 +264,12 @@ affecting execution.
 
 ID: `names`
 
-When a binary WebAssembly module is viewed in a browser or other development
-environment, the names in this section, when present, are used as the names of
-functions and locals in the [text format](TextFormat.md).
+The names section does not change execution semantics and a validation error in
+this section does not cause validation for the whole module to fail and is
+instead treated as if the section was absent. The expectation is that, when a
+binary WebAssembly module is viewed in a browser or other development
+environment, the names in this section will be used as the names of functions
+and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -106,11 +106,12 @@ above):
 * [End](#end-section) section
 * [Names](#names-section) section
 
-Known sections (from this list) may not appear out of order.
+Thus, the shortest valid module is 13 bytes (`magic number`, `version`,
+`size` = 4, `id_len` = 3, `id_str` = "end").
 
-The end of the last present section must coincide with the last byte of the
-module. The shortest valid module is 8 bytes (`magic number`, `version`,
-followed by zero sections).
+Additionally, known sections (from the above list) may not appear out of order
+and the end of the last present section must coincide with the last byte of the
+module. 
 
 ### Signatures section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -106,12 +106,11 @@ above):
 * [End](#end-section) section
 * [Names](#names-section) section
 
-Thus, the shortest valid module is 13 bytes (`magic number`, `version`,
-`size` = 4, `id_len` = 3, `id_str` = "end").
+Known sections (from this list) may not appear out of order.
 
-Additionally, known sections (from the above list) may not appear out of order
-and the end of the last present section must coincide with the last byte of the
-module. 
+The end of the last present section must coincide with the last byte of the
+module. The shortest valid module is 8 bytes (`magic number`, `version`,
+followed by zero sections).
 
 ### Signatures section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -89,10 +89,9 @@ for all sections. The encoding of all sections begins as follows:
 | id_len | `varuint32` | section identifier string length |
 | id_str | `bytes` | section identifier string of id_len bytes |
 
-Each section other than the End section is optional and may appear at most once.
-The End section must appear exactly once. If present, sections must occur in
-this precise order (interleaved or followed by unknown sections, as noted
-above):
+Each section other than the End section is optional and may appear at most once
+and only in the precise order defined below (out-of-order sections are a
+validation error).
 
 * [Signatures](#signatures-section) section
 * [Import Table](#import-table-section) section
@@ -106,12 +105,13 @@ above):
 * [End](#end-section) section
 * [Names](#names-section) section
 
-Thus, the shortest valid module is 13 bytes (`magic number`, `version`,
-`size` = 4, `id_len` = 3, `id_str` = "end").
+The End section must appear exactly once and is the last section that affects
+execution, including whether the module validates. Any validation error after
+the End section causes the containing section and all subsequent bytes to be
+ignored.
 
-Additionally, known sections (from the above list) may not appear out of order
-and the end of the last present section must coincide with the last byte of the
-module. 
+The shortest valid module is thus 13 bytes: `magic number`, `version`,
+`size` = `4`, `id_len` = `3`, `id_str` = `end`.
 
 ### Signatures section
 
@@ -264,12 +264,9 @@ affecting execution.
 
 ID: `names`
 
-The names section does not change execution semantics and a validation error in
-this section does not cause validation for the whole module to fail and is
-instead treated as if the section was absent. The expectation is that, when a
-binary WebAssembly module is viewed in a browser or other development
-environment, the names in this section will be used as the names of functions
-and locals in the [text format](TextFormat.md).
+When a binary WebAssembly module is viewed in a browser or other development
+environment, the names in this section, when present, are used as the names of
+functions and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |


### PR DESCRIPTION
This PR defines the order of sections so that an engine can walk down an optional list of sections and easily match section ids when decoding a module.

A rationale for the particular order in this PR:
* Signatures section needed by everything so it goes first.
* Imports section as early as possible to allow a streaming module loader to fire off parallel fetches asap.
* Indirect Function Table must go after Function Signatures
* Export Table goes after all declarations that may possibly get exported one day (e.g., the Indirect Function Table)
* The Start Function doesn't declare anything, so it goes after exports.
* Function bodies go before Data segments so that parallel compilation may occur while data is being streamed, but after everything else since this is the meat of the module.
* Names at the end since they don't semantically block anything.

Two other details in this PR to note/discuss:
* With inline everything, there isn't a need for an end section.  To be symmetric, this PR mirrors the current choice in function bodies to have byte length, not an explicit end marker, end the module.
* Unknown sections are said to be allowed between any two sections and there isn't any caveat that tries to catch out-of-order sections: if the order of two sections is flipped, the first one will just get ignored.  Happy to tighten this down if people wanted but it seemed like more work which might not actually help anyone.