### PR TITLE
Revise, update, and expand several Rationale entries.

### DIFF
--- a/Rationale.md
+++ b/Rationale.md
@@ -232,7 +232,7 @@ register allocation algorithms, offloading some of the optimization work from
 the WebAssembly VM.
 
 
-## Variable-Length Argument Lists
+## Variable-Length Argument Lists ("varargs")
 
 C and C++ compilers are expected to implement variable-length argument lists by
 storing arguments in a buffer in linear memory and passing a pointer to the

--- a/Rationale.md
+++ b/Rationale.md
@@ -205,12 +205,13 @@ variables by creating a separate stack data structure within linear memory. This
 stack is sometimes called the "aliased" stack, since it is used for variables
 which may be pointed to by pointers.
 
-This obstructs WebAssembly from performing clever optimizations on the stack and
-computing precise liveness of such variables, but this loss isn't expected to be
-consequential. Common compiler optimizations such as LLVM's global value
-numbering effectively split address-taken variables into parts, shrinking the
-range where they actually need to have their address taken, and creating new
-ranges where they can be allocated as local variables.
+Since the aliased stack appears to the WebAssembly engine as normal memory,
+WebAssembly optimizations that would target the aliased stack need to be more
+general, and thus more complicated. We observe that common compiler
+optimizations on the producer side, such as LLVM's global value numbering,
+effectively split address-taken variables into many small ranges that can often
+be allocated as local variables. Thus our expectation that any loss of
+optimization potential here is minimal.
 
 Conversely, non-address taken values which are usually on the stack are instead
 represented as locals inside functions. This effectively means that WebAssembly

--- a/Rationale.md
+++ b/Rationale.md
@@ -208,10 +208,10 @@ which may be pointed to by pointers.
 Since the aliased stack appears to the WebAssembly engine as normal memory,
 WebAssembly optimizations that would target the aliased stack need to be more
 general, and thus more complicated. We observe that common compiler
-optimizations on the producer side, such as LLVM's global value numbering,
-effectively split address-taken variables into many small ranges that can often
-be allocated as local variables. Thus our expectation that any loss of
-optimization potential here is minimal.
+optimizations done before the WebAssembly code is produced, such as LLVM's
+global value numbering, effectively split address-taken variables into many
+small ranges that can often be allocated as local variables. Thus our
+expectation that any loss of optimization potential here is minimal.
 
 Conversely, non-address taken values which are usually on the stack are instead
 represented as locals inside functions. This effectively means that WebAssembly

--- a/Rationale.md
+++ b/Rationale.md
@@ -44,7 +44,7 @@ WebAssembly only represents [a few types](AstSemantics.md#Types).
   language compiler to express its own types in terms of the basic machine
   types. This allows WebAssembly to present itself as a virtual ISA, and lets
   compilers target it as they would any other ISA.
-* These types are efficiently executed by all modern architectures.
+* These types are efficiently executed by all modern CPU architectures.
 * Smaller types (such as `i8` and `i16`) are usually no more efficient and in
   languages like C/C++ are only semantically meaningful for memory accesses
   since arithmetic get widened to `i32` or `i64`. Avoiding them at least for MVP


### PR DESCRIPTION
Note that this removes the "The history of ```nop``` instructions"
sentence, because the long history of ```nop``` instructions is mostly
about uses that don't apply to wasm: alignment padding, hazard avoidance,
vliw packing, branch delay slot stuffing, timing, and modifying code at
runtime. The one use that does apply to wasm is already described in the
preceding paragraph.