### PR TITLE
Add postorder opcodes

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -330,6 +330,7 @@ It is legal to have several entries with the same type.
 | `end` | `0x0f` | | end a block, loop, or if |
 
 The `br_table` operator has an immediate operand which is encoded as follows:
+Note that there is no explicit `if_else` opcode, as the else clause is encoded with the `else` bytecode.
 
 | Field | Type | Description |
 | ---- | ---- | ---- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -319,14 +319,15 @@ It is legal to have several entries with the same type.
 | `nop` | `0x00` | | no operation |
 | `block` | `0x01` | count = `varuint32` | a sequence of expressions, the last of which yields a value |
 | `loop` | `0x02` | count = `varuint32` | a block which can also form control flow loops |
-| `if` | `0x03` | | high-level one-armed if |
-| `if_else` | `0x04` | | high-level two-armed if |
+| `if` | `0x03` | | begin if expression |
+| `else` | `0x04` | | begin else expression of if |
 | `select` | `0x05` | | select one of two values based on condition |
 | `br` | `0x06` | relative_depth = `varuint32` | break that targets a outer nested block |
 | `br_if` | `0x07` | relative_depth = `varuint32` | conditional break that targets a outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
 | `return` | `0x14` | | return zero or one value from this function |
 | `unreachable` | `0x15` | | trap immediately |
+| `end` | `0x17` | | end a block, loop, or if |
 
 The `br_table` operator has an immediate operand which is encoded as follows:
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -317,17 +317,17 @@ It is legal to have several entries with the same type.
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
 | `nop` | `0x00` | | no operation |
-| `block` | `0x01` | count = `varuint32` | a sequence of expressions, the last of which yields a value |
-| `loop` | `0x02` | count = `varuint32` | a block which can also form control flow loops |
+| `block` | `0x01` |  | begin a sequence of expressions, the last of which yields a value |
+| `loop` | `0x02` |  | begin a block which can also form control flow loops |
 | `if` | `0x03` | | begin if expression |
 | `else` | `0x04` | | begin else expression of if |
 | `select` | `0x05` | | select one of two values based on condition |
 | `br` | `0x06` | relative_depth = `varuint32` | break that targets a outer nested block |
 | `br_if` | `0x07` | relative_depth = `varuint32` | conditional break that targets a outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
-| `return` | `0x14` | | return zero or one value from this function |
-| `unreachable` | `0x15` | | trap immediately |
-| `end` | `0x17` | | end a block, loop, or if |
+| `return` | `0x09` | | return zero or one value from this function |
+| `unreachable` | `0x0a` | | trap immediately |
+| `end` | `0x0f` | | end a block, loop, or if |
 
 The `br_table` operator has an immediate operand which is encoded as follows:
 
@@ -344,15 +344,15 @@ out of range, `br_table` branches to the default target.
 ## Basic operators ([described here](AstSemantics.md#constants))
 | Name | Opcode | Immediate | Description |
 | ---- | ---- | ---- | ---- |
-| `i32.const` | `0x0a` | value = `varint32` | a constant value interpreted as `i32` |
-| `i64.const` | `0x0b` | value = `varint64` | a constant value interpreted as `i64` |
-| `f64.const` | `0x0c` | value = `uint64` | a constant value interpreted as `f64` |
-| `f32.const` | `0x0d` | value = `uint32` | a constant value interpreted as `f32` |
-| `get_local` | `0x0e` | local_index = `varuint32` | read a local variable or parameter |
-| `set_local` | `0x0f` | local_index = `varuint32` | write a local variable or parameter |
-| `call` | `0x12` | function_index = `varuint32` | call a function by its index |
-| `call_indirect` | `0x13` | signature_index = `varuint32` | call a function indirect with an expected signature |
-| `call_import` | `0x1f` | import_index = `varuint32` | call an imported function by its index |
+| `i32.const` | `0x10` | value = `varint32` | a constant value interpreted as `i32` |
+| `i64.const` | `0x11` | value = `varint64` | a constant value interpreted as `i64` |
+| `f64.const` | `0x12` | value = `uint64` | a constant value interpreted as `f64` |
+| `f32.const` | `0x13` | value = `uint32` | a constant value interpreted as `f32` |
+| `get_local` | `0x14` | local_index = `varuint32` | read a local variable or parameter |
+| `set_local` | `0x15` | local_index = `varuint32` | write a local variable or parameter |
+| `call` | `0x16` | function_index = `varuint32` | call a function by its index |
+| `call_indirect` | `0x17` | signature_index = `varuint32` | call a function indirect with an expected signature |
+| `call_import` | `0x18` | import_index = `varuint32` | call an imported function by its index |
 
 ## Memory-related operators ([described here](AstSemantics.md#linear-memory-accesses))
 


### PR DESCRIPTION
Add opcodes for `else` and `end`. Remove the `if_else` opcode. Remove counts from blocks and loops.

Note also that this PR slightly rearranges the lower opcode space to put all the control operators in order and leave a little hole between `0x0a` and `0x0f` for adding a `catch` operator in the future.