### PR TITLE
make the maximum memory size a hard limit and update grow_memory return value

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -208,9 +208,12 @@ the [future](FutureFeatures.md#large-page-support)).
  * `grow_memory` : grow linear memory by a given unsigned delta of pages.
     Return the previous memory size in units of pages or -1 on failure.
 
-`grow_memory` must fail when attempting to grow past the maximum declared
-size, if one is specified in the [memory section](Module.md#linear-memory-section).
-`grow_memory` may also fail if an underlying system allocation fails.
+When a maximum memory size is declared in the [memory section](Module.md#linear-memory-section),
+`grow_memory` must fail if it would grow past the maximum. However,
+`grow_memory` may still fail before the maximum if it was not possible to
+reserve the space up front or if enabling the reserved memory fails.
+When there is no maximum memory size declared, `grow_memory` is expected
+to perform a system allocation which may fail.
 
 As stated [above](AstSemantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -202,11 +202,15 @@ Out of bounds accesses trap.
 
 In the MVP, linear memory can be resized by a `grow_memory` operator. The
 operand to this operator is in units of the WebAssembly page size,
-which is 64KiB on all engines (though large page support may be added in 
+which is defined to be 64KiB (though large page support may be added in 
 the [future](FutureFeatures.md#large-page-support)).
 
  * `grow_memory` : grow linear memory by a given unsigned delta of pages.
-    Return the previous memory size in bytes.
+    Return the previous memory size in units of pages or -1 on failure.
+
+`grow_memory` must fail when attempting to grow past the maximum declared
+size, if one is specified in the [memory section](Module.md#linear-memory-section).
+`grow_memory` may also fail if an underlying system allocation fails.
 
 As stated [above](AstSemantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the

--- a/Modules.md
+++ b/Modules.md
@@ -161,14 +161,19 @@ by the module. If the section is absent, the linear memory operators
 The linear memory section declares the initial [memory size](AstSemantics.md#linear-memory)
 (which may be subsequently increased by [`grow_memory`](AstSemantics.md#resizing)).
 
+The linear memory section may optionally declare a maximum memory size.
+[`grow_memory`](AstSemantics.md#resizing) is guaranteed to fail if attempting to
+grow past the declared maximum. When declared, implementations *should*
+(non-normative) attempt to reserve virtual memory up to the maximum size. While
+failure to allocate the *initial* memory size is a runtime error, failure to
+reserve up to the *maximum* is not. When a maximum memory size is *not* declared,
+on architectures with limited virtual address space, engines should allocate
+only the initial size and reallocate on demand.
+
 The initial contents of linear memory are zero by default. However, the memory
 section contains a possibly-empty array of *segments* (analogous to `.data`)
 which can specify the initial contents of fixed `(offset, length)` ranges of
 memory.
-
-The linear memory section may also contain an optional hint declaring the expected
-maximum heap usage. This hint is not semantically visible but can help a
-WebAssembly engine to optimize `grow_memory`.
 
 The linear memory section may optionally declare that the instance's
 linear memory is *externally aliasable*. How linear memory is aliased is up


### PR DESCRIPTION
Reflecting multiple previous discussions and vetting by a number of stakeholders, this PR changes the maximum memory size (specified in the memory section) to be a hard limit.  It's already optional; that doesn't change.  For the rationale for this design, see additions to Rationale.md in this PR.

Since this PR is touching `grow_memory` and since we've moved basically everything to units of pages (including the operand of `grow_memory`), this PR also changes `grow_memory`'s return value to be in units of pages.

Less trivial, but also already discussed with initial consensus, the return value of `grow_memory` is updated to return -1 on failure.  0 is the other obvious candidate, but given that we don't prevent initial memory sizes of 0 or `grow_memory` deltas of 0, it seems like 0 is a valid return value of `grow_memory`.  With units of pages and wasm32, -1 (UINT32_MAX as an unsigned) is not a valid memory_size.  Presumably, wasm64 would return an `int64` for which -1 (UINT64_MAX) would also be an invalid memory size.