### PR TITLE
Add current_memory operator

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -82,18 +82,19 @@ operators.
 
 The main storage of a WebAssembly instance, called the *linear memory*, is a
 contiguous, byte-addressable range of memory spanning from offset `0` and
-extending for `memory_size` bytes which can be dynamically grown by
-[`grow_memory`](AstSemantics.md#resizing). The linear memory can be considered
+extending up to a varying *memory size*.
+This size always is a multiple of the WebAssembly page size,
+which is 64KiB on all engines (though large page support may be added in the
+[future](FutureFeatures.md#large-page-support)).
+The initial state of linear memory is specified by the
+[module](Modules.md#linear-memory-section), and it can be dynamically grown by
+the [`grow_memory`](AstSemantics.md#resizing) operator.
+
+The linear memory can be considered
 to be an untyped array of bytes, and it is unspecified how embedders map this
 array into their process' own [virtual memory][]. The linear memory is
 sandboxed; it does not alias the execution engine's internal data structures,
 the execution stack, local variables, or other process memory.
-
-The initial state of linear memory is specified by the
-[module](Modules.md#linear-memory-section). The initial and maximum memory size
-are required to be a multiple of the WebAssembly page size, which is 64KiB on
-all engines (though large page support may be added in the
-[future](FutureFeatures.md#large-page-support)).
 
   [virtual memory]: https://en.wikipedia.org/wiki/Virtual_memory
 
@@ -152,7 +153,7 @@ interpreted as an unsigned byte index.
 
 Linear memory operators access the bytes starting at the effective address and
 extend for the number of bytes implied by the storage size. If any of the
-accessed bytes are beyond `memory_size`, the access is considered
+accessed bytes are beyond the current memory size, the access is considered
 *out-of-bounds*.
 
 The use of infinite-precision in the effective address computation means that
@@ -217,7 +218,7 @@ to perform a system allocation which may fail.
 
 The current size of the linear memory can be queried by the following operator:
 
-  * `current_memory` : return the current size of the linear memory in units of pages.
+  * `current_memory` : return the current memory size in units of pages.
 
 As stated [above](AstSemantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the

--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -215,6 +215,10 @@ reserve the space up front or if enabling the reserved memory fails.
 When there is no maximum memory size declared, `grow_memory` is expected
 to perform a system allocation which may fail.
 
+The current size of the linear memory can be queried by the following operator:
+
+  * `current_memory` : return the current size of the linear memory in units of pages.
+
 As stated [above](AstSemantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the
 MVP, there are [future features](FutureFeatures.md#finer-grained-control-over-memory)


### PR DESCRIPTION
After #629, the `memory_size` operator (which actually was missing from AstSemantics) is the last one not counting memory in page units. This PR species that, and also renames it to `current_memory` (as suggested [here](https://github.com/WebAssembly/spec/pull/273#issuecomment-206956351)).