### PR TITLE
Remove `loop`'s bottom label.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -256,7 +256,7 @@ a value and may appear as children of other expressions.
 
  * `nop`: an empty operator that does not yield a value 
  * `block`: a fixed-length sequence of expressions with a label at the end
- * `loop`: a block with an additional label at the beginning which may be used to form loops
+ * `loop`: a fixed-length sequence of expressions with a label at the beginning
  * `if`: if expression with a list of *then* expressions and a list of *else* expressions
  * `br`: branch to a given label in an enclosing construct
  * `br_if`: conditionally branch to a given label in an enclosing construct
@@ -288,7 +288,7 @@ The `nop`, `br`, `br_if`, `br_table`, and `return` constructs do not yield value
 Other control constructs may yield values if their subexpressions yield values:
 
 * `block`: yields either the value of the last expression in the block or the result of an inner branch that targeted the label of the block
-* `loop`: yields either the value of the last expression in the loop or the result of an inner branch that targeted the end label of the loop
+* `loop`: yields the value of the last expression in the loop
 * `if`: yields either the value of the last *then* expression or the last *else* expression or the result of an inner branch that targeted the label of one of these.
 
 In all constructs containing block-like sequences of expressions, all expressions but the last must not yield a value.


### PR DESCRIPTION
This proposes simplifying `loop` by removing its bottom label, so
that it only has a top label. This establishes a nice consistency
in having every scoped construct -- `block`, `loop`, `if`, `else`,
and function body -- add exactly one "level" to the scope depth.

When a `loop` exit label is needed, an explicit `block` can be
used. In practice, `loop` is typically less than 1% of all nodes,
and beyond that, the majority of `loop`s in practice don't use
their bottom label anyway.

In the s-expression format with both labels at the top, I often
forget which label is for the top and which is for the bottom. And
it can be awkward in other possible formats as well, requiring
either multiple labels or additional disambiguation.

And while it's not complicated to implement loop as a two-level
construct (having done it myself, both as a producer and as a
consumer), it is an odd special case.