### PR TITLE
Rename fields in memory section

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -178,8 +178,8 @@ associated with the module.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| min_mem_pages | `varuint32` | minimize memory size in 64KiB pages |
-| max_mem_pages | `varuint32` | maximum memory size in 64KiB pages |
+| initial | `varuint32` | initial memory size in 64KiB pages |
+| max | `varuint32` | maximum memory size in 64KiB pages |
 | exported | `uint8` | `1` if the memory is visible outside the module |
 
 ### Export Table section

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -179,7 +179,7 @@ associated with the module.
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | initial | `varuint32` | initial memory size in 64KiB pages |
-| max | `varuint32` | maximum memory size in 64KiB pages |
+| maximum | `varuint32` | maximum memory size in 64KiB pages |
 | exported | `uint8` | `1` if the memory is visible outside the module |
 
 ### Export Table section


### PR DESCRIPTION
Does not affect the spec, but I think `initial` is a better name than `minimum` since the `initial` isn't necessarily the `minimum` if, in the future, we were to add a `shrink_memory` + `minimum` (which could be <= `initial`).  The PR also renames `max` to be more consistent with other names in this file.