### PR TITLE
Text fix in BinaryEncoding

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -336,8 +336,9 @@ It is legal to have several entries with the same type.
 | `unreachable` | `0x0a` | | trap immediately |
 | `end` | `0x0f` | | end a block, loop, or if |
 
-The `br_table` operator has an immediate operand which is encoded as follows:
 Note that there is no explicit `if_else` opcode, as the else clause is encoded with the `else` bytecode.
+
+The `br_table` operator has an immediate operand which is encoded as follows:
 
 | Field | Type | Description |
 | ---- | ---- | ---- |


### PR DESCRIPTION
Two lines seem to be in the wrong order. The br_table comment talks about the table below it, so the if-else statement should mind its own business.