### PR TITLE
Simplify br_if by removing its value operand.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -278,9 +278,8 @@ further see the parallel, note that a `br` to a `block`'s label is functionally
 equivalent to a labeled `break` in high-level languages in that a `br` simply
 breaks out of a `block`.
 
-Branches that exit a `block`, `loop`, or `br_table` may take a subexpression
-that yields a value for the exited construct. If present, it is the first operand
-before any others.
+`br` and `br_table` may take a subexpression that yields a value for the exited
+construct. If present, it is the first operand before any others.
 
 ### Yielding values from control constructs
 


### PR DESCRIPTION
#677 is the latest in a long and complex discussion (https://github.com/WebAssembly/spec/issues/179, https://github.com/WebAssembly/spec/pull/180, https://github.com/WebAssembly/spec/pull/271, and others) about how to impose high-level typing rules on an assembly-style branch instruction. I and several other people actively involved in WebAssembly's design have been confused about what the rules are, which is not auspicious for its broader adventures.

The current state, where `br_if` has a value operand, but no return value, may satisfy certain properties relevant to the high-level typing system, but it is awkward from an assembly perspective, which is the perspective that motivated the instruction in the first place. It's essentially creating an optimized path for the case where a value is live on the branch-taken side of the branch but not the fallthrough side.

The bigger picture is that I don't think we've had the appropriate chance to figure out how we really want this instruction to work. I propose that `br_if`'s arity be limited to 0 in the MVP. We can change it to permit 1 in the future when we work out how we want it to work.

Addressing the concern of code size, the numbers being quoted for block return values in general are in the neighborhood of 1%. I don't know the specific fraction of that which involves `br_if`, but even in the worst case, I claim this is rounding error when compared to the broader concern of designing a clean language.