### PR TITLE
Make opcode 0x00 `unreachable`.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -326,7 +326,7 @@ It is legal to have several entries with the same type.
 
 | Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
-| `nop` | `0x00` | | no operation |
+| `unreachable` | `0x00` | | trap immediately |
 | `block` | `0x01` |  | begin a sequence of expressions, the last of which yields a value |
 | `loop` | `0x02` |  | begin a block which can also form control flow loops |
 | `if` | `0x03` | | begin if expression |
@@ -336,7 +336,7 @@ It is legal to have several entries with the same type.
 | `br_if` | `0x07` | argument_count : `varuint1`, relative_depth : `varuint32` | conditional break that targets an outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
 | `return` | `0x09` | argument_count : `varuint1` | return zero or one value from this function |
-| `unreachable` | `0x0a` | | trap immediately |
+| `nop` | `0x0a` | | no operation |
 | `end` | `0x0f` | | end a block, loop, or if |
 
 Note that there is no explicit `if_else` opcode, as the else clause is encoded with the `else` bytecode.


### PR DESCRIPTION
Make opcode 0x00 `unreachable`, and move `nop` to a non-zero opcode.

All-zeros is one of the more common patterns of corrupted data. This
change makes it more likely that code that is accidentally zeroed, in
whole or in part, will be noticed when executed rather than silently
running through a nop slide.

Obviously, this doesn't matter when an opcode table is present, but
if there is a default opcode table, it would presumably use the
opcodes defined here.