### PR TITLE
Make dropping of values explicit

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -242,6 +242,7 @@ of the arguments passed to the function.
 
   * `get_local`: read the current value of a local variable
   * `set_local`: set the current value of a local variable
+  * `tee_local`: like `set_local`, but also returns the set value
 
 The details of index space for local variables and their types will be further clarified,
 e.g. whether locals with type `i32` and `i64` must be contiguous and separate from


### PR DESCRIPTION
Luke, Ben, Dan, and I have been discussing this change for slightly simplifying Wasm, and allowing a more natural interpretation of Wasm as a stack machine. The main changes are:

- Values can no longer be discarded implicitly.
- Instead, there is an explicit `drop` operator.
- To compensate, store operators no longer return a value.

The constructs affected by this are mainly blocks and block-like sequences. Before, all expressions in a block could yield a value, and it would just be dropped on the floor implicitly (except the last one). Now we require explicit drop operations in those cases. With stores no longer returning a value, the only places were we expect drops to actually arise are _calls_ to side-effecting functions that also return a value, but this value isn't used.

(Also fixing a bunch of other out-of-date text on the way.)

The corresponding spec changes can be found here for more details:

  https://github.com/WebAssembly/spec/compare/void