### PR TITLE
Put f32.const before f64.const, for consistency.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -1,13 +1,18 @@
 # Abstract Syntax Tree Semantics
 
-WebAssembly code is represented as an Abstract Syntax Tree (AST) where each node
-represents an expression. Each function body consists of a list of expressions.
-All expressions and operators are typed, with no implicit conversions or overloading rules.
+This document describes WebAssembly semantics. The description here is written
+in terms of an Abstract Syntax Tree (AST), however it is also possible to
+understand WebAssembly semantics in terms of a stack machine. (In practice,
+implementations need not build an actual AST or maintain an actual stack; they
+need only behave [as if](https://en.wikipedia.org/wiki/As-if_rule) they did so.)
 
 This document explains the high-level design of the AST: its types, constructs, and
 semantics. For full details consult [the formal Specification](https://github.com/WebAssembly/spec),
 for file-level encoding details consult [Binary Encoding](BinaryEncoding.md),
 and for the human-readable text representation consult [Text Format](TextFormat.md).
+
+Each function body consists of a list of expressions. All expressions and
+operators are typed, with no implicit conversions or overloading rules.
 
 Verification of WebAssembly code requires only a single pass with constant-time
 type checking and well-formedness checking.

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -363,8 +363,8 @@ out of range, `br_table` branches to the default target.
 | ---- | ---- | ---- | ---- |
 | `i32.const` | `0x10` | value : `varint32` | a constant value interpreted as `i32` |
 | `i64.const` | `0x11` | value : `varint64` | a constant value interpreted as `i64` |
-| `f64.const` | `0x12` | value : `uint64` | a constant value interpreted as `f64` |
-| `f32.const` | `0x13` | value : `uint32` | a constant value interpreted as `f32` |
+| `f32.const` | `0x12` | value : `uint32` | a constant value interpreted as `f32` |
+| `f64.const` | `0x13` | value : `uint64` | a constant value interpreted as `f64` |
 | `get_local` | `0x14` | local_index : `varuint32` | read a local variable or parameter |
 | `set_local` | `0x15` | local_index : `varuint32` | write a local variable or parameter |
 | `call` | `0x16` | argument_count : `varuint1`, function_index : `varuint32` | call a function by its index |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -326,7 +326,7 @@ It is legal to have several entries with the same type.
 
 | Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
-| `nop` | `0x00` | | no operation |
+| `unreachable` | `0x00` | | trap immediately |
 | `block` | `0x01` |  | begin a sequence of expressions, the last of which yields a value |
 | `loop` | `0x02` |  | begin a block which can also form control flow loops |
 | `if` | `0x03` | | begin if expression |
@@ -336,7 +336,7 @@ It is legal to have several entries with the same type.
 | `br_if` | `0x07` | argument_count : `varuint1`, relative_depth : `varuint32` | conditional break that targets an outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
 | `return` | `0x09` | argument_count : `varuint1` | return zero or one value from this function |
-| `unreachable` | `0x0a` | | trap immediately |
+| `nop` | `0x0a` | | no operation |
 | `end` | `0x0f` | | end a block, loop, or if |
 
 Note that there is no explicit `if_else` opcode, as the else clause is encoded with the `else` bytecode.


### PR DESCRIPTION
This is for the binary_0xc branch, and is one step of a broader opcode reorganization.
