### PR TITLE
Have br_if return its value

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -291,6 +291,7 @@ Other control constructs may yield values if their subexpressions yield values:
 * `block`: yields either the value of the last expression in the block or the result of an inner `br` that targeted the label of the block
 * `loop`: yields either the value of the last expression in the loop or the result of an inner `br` that targeted the end label of the loop
 * `if_else`: yields either the value of the true expression or the false expression
+* `br_if`: yields the branch value if the branch is not taken
 
 
 ### `br_table`


### PR DESCRIPTION
Currently, AstSemantics.md and ml-proto say that `br_if` doesn't return a value.  However, V8 and SM wasm impls currently both have `br_if` return its value (mostly as an oversight, but also b/c that's what happens with an stack-based iterative algorithm unless you take special steps to pop and void the value).  I think `br_if`-returning its value is more natural for a couple of reasons:
* it's weird for a value computed before a branch to only be usable along one of its successor edges
* from a stack-based POV (i.e., the current validator/compiler of V8/SM), it's weird for `br_if` to conditionally pop the value
* the whole point of branch values is to "pass along" a value, so from an expression POV, it seems natural for `br_if` to pass along its value to the parent expression

(This PR is currently based on #694.)