### PR TITLE
Simplify br_if by removing its value operand.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -278,9 +278,8 @@ further see the parallel, note that a `br` to a `block`'s label is functionally
 equivalent to a labeled `break` in high-level languages in that a `br` simply
 breaks out of a `block`.
 
-Branches that exit a `block`, `loop`, or `br_table` may take a subexpression
-that yields a value for the exited construct. If present, it is the first operand
-before any others.
+`br` and `br_table` may take a subexpression that yields a value for the exited
+construct. If present, it is the first operand before any others.
 
 ### Yielding values from control constructs
 


### PR DESCRIPTION
This proposes removing br_if's value operand (effectively by fixing the arity to 0) to defer the question of how its return value should be handled. We'd have the flexibility to reintroduce this operand in the future.

This new PR is in place of reopening https://github.com/WebAssembly/design/pull/681 which github won't let me re-open.