### PR TITLE
Add a bitwise-or form of NaN propagation.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -455,17 +455,20 @@ implementations of the remaining required operators.
 
 When the result of any arithmetic operation other than `neg`, `abs`, or
 `copysign` is a NaN, the sign bit and the fraction field (which does not include
-the implicit leading digit of the significand) of the NaN are computed as
-follows:
+the implicit leading digit of the significand) of the NaN are computed according
+to a nondeterministic choice between the following alternatives:
 
- - If the operation has any NaN input values, implementations may select any of
-   them to be the result value, but with the most significant bit of the
-   fraction field overwritten to be 1.
+ - If the operation has any NaN input values, implementations may choose any one
+   of them, nondeterministically, to be the result value, but with the most
+   significant bit of the fraction field overwritten to be 1.
 
- - If the implementation does not choose to use an input NaN as a result value,
-   or if there are no input NaNs, the result value has a nondeterministic sign
-   bit, a fraction field with 1 in the most significant bit and 0 in the
-   remaining bits.
+ - If the operation has any NaN input values, implementations may alternatively
+   choose to produce a NaN containing the bitwise-or of all the bits of the
+   input NaN values, also with the most significant bit of the fraction field
+   overwritten to be 1.
+
+ - Otherwise, the result value has a nondeterministic sign bit, a fraction field
+   with 1 in the most significant bit and 0 in the remaining bits.
 
 32-bit floating point operations are as follows:
 


### PR DESCRIPTION
I recently read about a CPU which has NaN propagation behavior that is not supported by WebAssembly.

This PR proposes to augment WebAssembly's NaN rules to say that when there are multiple NaN inputs, the return can be computed by bitwise-or'ing them together. This change:
 - requires no changes in existing implementations
 - is basically compatible with the NaN-boxing-on-wasm scheme the current NaN rules aim to support
 - keeps nondeterminism quite limited while still supporting current and anticipated hardware designs

That said, the NaN rules are already fairly complex, and this would make them even more so, and it does slightly increase nondeterminism. Dropping the goal of supporting NaN boxing on top of wasm, and/or accepting greater nondeterminism in NaN bits, could simplify the spec in this area.