### PR TITLE
Provide overview of security model

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -95,10 +95,10 @@ And in practice, popular C and C++ compilers do optimize on the assumption that
 alignment rules are followed, meaning that they don't always preserve program
 behavior otherwise.
 
-On WebAssembly, the primary invariants
-[are always maintained](Nondeterminism.md). Demons can't actually fly out your
-nose, as that would constitute an escape from the sandbox. And, callstacks can't
-become corrupted.
+On WebAssembly, the primary [nondeterminism](Nondeterminism.md) and
+[security](Security.md) invariants are always maintained. Demons can't actually
+fly out your nose, as that would constitute an escape from the sandbox. And,
+callstacks can't become corrupted.
 
 Other than that, programs which invoke undefined behavior at the source language
 level may be compiled into WebAssembly programs which do anything else,

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -1,7 +1,7 @@
 # Nondeterminism in WebAssembly
 
-WebAssembly is a [portable](Portability.md) sandboxed platform with limited,
-local, nondeterminism. 
+WebAssembly is a [portable](Portability.md) [sandboxed](Security.md) platform
+with limited, local, nondeterminism.
   * *Limited*: nondeterministic execution can only occur in a small number of
     well-defined cases (described below) and, in those cases, the implementation
     may select from a limited set of possible behaviors.
@@ -10,15 +10,6 @@ local, nondeterminism.
 
 The [rationale](Rationale.md) document details why WebAssembly is designed as
 detailed in this document.
-
-The limited, local, nondeterministic model implies:
-  * Applications can't access data outside the sandbox without going through
-    appropriate APIs, or otherwise escape the sandbox.
-  * WebAssembly always maintains valid, trusted callstacks; stray pointer writes
-    cannot corrupt return addresses or spilled variables on the stack.
-  * Calls and branches always have valid destinations ensuring 
-    [Control Flow Integrity](https://research.microsoft.com/apps/pubs/default.aspx?id=64250).
-  * WebAssembly has no [nasal demons](https://en.wikipedia.org/w/index.php?title=Nasal_demons).
 
 The following is a list of the places where the WebAssembly specification
 currently admits nondeterminism:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WebAssembly is currently being designed as an open standard by a [W3C Community 
 
 - **WebAssembly is efficient and fast**: The wasm [AST](AstSemantics.md) is designed to be encoded in a size- and load-time-efficient [binary format](BinaryEncoding.md). WebAssembly aims to execute at native speed by taking advantage of [common hardware capabilities](Portability.md#assumptions-for-efficient-execution) available on a wide range of platforms.
 
-- **WebAssembly is safe**: WebAssembly describes a memory-safe, sandboxed [execution environment](AstSemantics.md#linear-memory) that may even be implemented inside existing JavaScript virtual machines.  When [embedded in the web](Web.md), WebAssembly will enforce the same-origin and permissions security policies of the browser.
+- **WebAssembly is safe**: WebAssembly describes a [memory-safe](Security.md#memory-safety), sandboxed [execution environment](AstSemantics.md#linear-memory) that may even be implemented inside existing JavaScript virtual machines.  When [embedded in the web](Web.md), WebAssembly will enforce the same-origin and permissions security policies of the browser.
 
 - **WebAssembly is open and debuggable**: WebAssembly is designed to be pretty-printed in a [textual format](TextFormat.md) for debugging, testing, experimenting, optimizing, learning, teaching, and writing programs by hand. The textual format will be used when [viewing the source](FAQ.md#will-webassembly-support-view-source-on-the-web) of wasm modules on the web.
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -192,9 +192,9 @@ may be added in the future.
 
 ## Nop
 
-The nop operator does not produce a value or cause side effects. 
+The nop operator does not produce a value or cause side effects.
 It is nevertheless useful for compilers and tools, which sometimes need to replace instructions with a ```nop```. Without a ```nop``` instruction, code generators would use alternative *does-nothing* opcode patterns that consume space in a module and may have a runtime cost. Finding an appropriate opcode that does nothing but has the appropriate type for the node's location is nontrivial. The existence of many different ways to encode ```nop``` - often mixed in the same module - would reduce the efficiency of compression algorithms.
- 
+
 
 ## Locals
 
@@ -317,7 +317,7 @@ practical way to:
 * Reduce implementation complexity (both of WebAssembly VMs as well as compilers
   generating WebAssembly binaries).
 * Allow usage of new hardware features.
-* Allows implementations to security-harden certain usecases.
+* Allows implementations to [security-harden](Security.md) certain usecases.
 
 When nondeterminism is allowed into WebAssembly it is always done in a limited
 and local manner. This prevents the entire program from being invalid, as would

--- a/Security.md
+++ b/Security.md
@@ -1,0 +1,122 @@
+# Security
+
+The security model of WebAssembly has two important goals: (1) protect *users*
+from buggy or malicious modules, and (2) provide *developers* with useful
+primitives and mitigations for developing safe applications, within the
+constraints of (1).
+
+## Users
+
+Each WebAssembly module executes within a sandboxed environment separated from
+the host runtime using fault isolation techniques. This implies:
+  * Applications execute independently, and can't escape the sandbox without
+  going through appropriate APIs.
+  * Applications generally execute deterministically
+  [with limited exceptions](Nondeterminism.md).
+
+Additionally, each module is subject to the security policies of its embedding.
+Within a [web browser](Web.md), this includes restrictions on information flow
+through [same-origin policy][]. On a [non-web](NonWeb.md) platform, this could
+include the POSIX security model.
+
+## Developers
+
+The design of WebAssembly promotes safe programs by eliminating dangerous
+features from its execution semantics, while maintaining compatibility with
+programs written for [C/C++](CandC++.md).
+
+Modules must declare all accessible functions and their associated types
+at load time, even when [dynamic linking](DynamicLinking.md) is used. This
+allows implicit enforcement of [control-flow integrity][] (CFI) through
+structured control-flow. Since compiled code is immutable and not observable at
+runtime, WebAssembly programs are protected from control flow hijacking attacks.
+  * [Function calls](AstSemantics.md#calls) must specify the index of a target
+  that corresponds to a valid entry in the
+  [function index space](Modules.md#function-index-space) or
+  [table index space](Modules.md#table-index-space).
+  * [Indirect function calls](Rationale.md#indirect-calls) are subject to a type
+  signature check at runtime; the type signature of the selected indirect
+  function must match the type signature specified at the call site.
+  * A shadow stack is used to maintain a trusted call stack that is invulnerable
+  to buffer overflows in the module heap, ensuring safe function returns.
+  * [Branches](AstSemantics.md#branches-and-nesting) must point to valid
+  destinations within the enclosing function.
+
+Variables in C/C++ can be lowered to two different primitives in WebAssembly,
+depending on their scope. [Local variables](AstSemantics.md#local-variables)
+with fixed scope and [global variables](AstSemantics.md#global-variables) are
+represented as fixed-type values stored by index. The former are initialized
+to zero by default and are stored in the protected shadow stack, whereas
+the latter are located in the [global index space](Modules.md#global-index-space)
+and can be imported from external modules. Local variables with
+[unclear static scope](Rationale.md#locals) (e.g. are used by the address-of
+operator, or are of type `struct` and returned by value) are stored in a separate
+user-addressable stack in [linear memory](AstSemantics.md#linear-memory) at
+compile time. This is an isolated memory region with fixed maximum size that is
+zero initialized by default. References to this memory are computed with
+infinite precision to avoid wrapping and simplify bounds checking. In the future,
+support for [multiple linear memory sections](Modules.md#linear-memory-section) and
+[finer-grained memory operations](FutureFeatures.md#finer-grained-control-over-memory)
+(e.g. shared memory, page protection, large pages, etc.) will be implemented.
+
+[Traps](AstSemantics.md#traps) are used to immediately terminate execution and
+signal abnormal behavior to the execution environment. In a browser, this is
+represented as a JavaScript exception. Support for
+[module-defined trap handlers](FutureFeatures.md#trappingor-non-trapping-strategies)
+will be implemented in the future. Operations that can trap include:
+  * specifying an invalid index in any index space,
+  * performing an indirect function call with a mismatched signature,
+  * exceeding the maximum size of the protected call stack,
+  * accessing [out-of-bounds](#Rationale.md#out-of-bounds) addresses in linear
+  memory,
+  * executing an illegal arithmetic operations (e.g. division or remainder by
+  zero, signed division overflow, etc).
+
+### Memory Safety
+Compared to traditional C/C++ programs, these semantics obviate certain classes
+of memory safety bugs in WebAssembly. Buffer overflows, which occur when data
+exceeds the boundaries of an object and accesses adjacent memory regions, cannot
+affect local or global variables stored in index space, they are fixed-size and
+addressed by index. Data stored in linear memory can overwrite adjacent objects,
+since bounds checking is performed at linear memory region granularity and is
+not context-sensitive. However, the presence of control-flow integrity and
+protected shadow call stacks prevents direct code injection attacks. Thus,
+common mitigations such as [data execution prevention][] (DEP) and
+[stack smashing protection][] (SSP) are not needed by WebAssembly programs.
+
+Another common class of memory safety errors involves unsafe pointer usage and
+[undefined behavior](CandC++.md#undefined-behavior). This includes dereferencing
+pointers to unallocated memory (e.g. `NULL`), or freed memory allocations. In
+WebAssembly, the semantics of pointers have been eliminated for function calls
+and variables with fixed static scope, allowing references to invalid indexes in
+any index space to trigger a validation error at load time, or at worst a trap
+at runtime. Accesses to linear memory are bounds-checked at the region level,
+potentially resulting in a trap at runtime. These memory region(s) are isolated
+from the internal memory of the runtime, and are set to zero by default unless
+otherwise initialized.
+
+Nevertheless, other classes of bugs are not obviated by the semantics of
+WebAssembly. Although attackers cannot perform direct code injection attacks,
+it is possible to hijack the control flow of a module using code reuse attacks
+against indirect calls. However, conventional [return-oriented programming][]
+(ROP) attacks using short sequences of instructions ("gadgets") are not possible
+in WebAssembly, because control-flow integrity ensures that call targets are
+valid functions declared at load time. Likewise, race conditions, such as
+[time of check to time of use][] (TOCTOU) vulnerabilities, are possible in
+WebAssembly, since no execution or scheduling guarantees are provided beyond
+in-order execution and [post-MVP atomic memory primitives](PostMVP.md#threads).
+Similarly, [side channel attacks][] can occur, such as timing attacks against
+modules. In the future, additional protections may be provided by runtimes or
+the toolchain, such as code diversification or memory randomization (similar to
+[address space layout randomization][] (ASLR)), [bounded pointers][] ("fat"
+pointers), or finer-grained control-flow integrity.
+
+  [address space layout randomization]: https://en.wikipedia.org/wiki/Address_space_layout_randomization
+  [bounded pointers]: https://en.wikipedia.org/wiki/Bounded_pointer
+  [control-flow integrity]: https://research.microsoft.com/apps/pubs/default.aspx?id=64250
+  [data execution prevention]: https://en.wikipedia.org/wiki/Executable_space_protection
+  [return-oriented programming]: https://en.wikipedia.org/wiki/Return-oriented_programming
+  [same-origin policy]: https://www.w3.org/Security/wiki/Same_Origin_Policy
+  [side channel attacks]: https://en.wikipedia.org/wiki/Side-channel_attack
+  [stack smashing protection]: https://en.wikipedia.org/wiki/Buffer_overflow_protection#Random_canaries
+  [time of check to time of use]: https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use

--- a/Tooling.md
+++ b/Tooling.md
@@ -32,13 +32,13 @@ The tooling we expect to support includes:
     programs, inspecting their state, modifying their state.
   - Debug information is better delivered on-demand instead of built-in to a
     WebAssembly module.
-* Sanitizers for non-memory-safe languages: asan, tsan, msan, ubsan. Efficient
-  support of sanitizers may require improving:
+* Sanitizers for [non-memory-safe](Security.md#memory-safety) languages: asan,
+  tsan, msan, ubsan. Efficient support of sanitizers may require improving:
   - Trapping support;
   - Shadow stack techniques (often implemented through `mmap`'s `MAP_FIXED`).
-* Opt-in security enhancements for developers' own code: developers targeting
-  WebAssembly may want their own code to be sandboxed further than what
-  WebAssembly implementations require to protect users.
+* Opt-in [security](Security.md) enhancements for developers' own code:
+  developers targeting WebAssembly may want their own code to be sandboxed
+  further than what WebAssembly implementations require to protect users.
 * Profilers:
   - Sample-based;
   - Instrumentation-based.

--- a/Web.md
+++ b/Web.md
@@ -58,10 +58,10 @@ rule is only mandatory for Web embedding.
 
 ## Security
 
-WebAssembly's security model should depend on [CORS][] and
-[subresource integrity][] to enable distribution, especially through content
-distribution networks and to implement
-[dynamic linking](DynamicLinking.md).
+WebAssembly's [security](Security.md) model should depend on the
+[same-origin policy][], with [cross-origin resource sharing (CORS)][] and
+[subresource integrity][] to enable distribution through content
+distribution networks and to implement [dynamic linking](DynamicLinking.md).
 
 ## SIMD
 
@@ -75,6 +75,7 @@ Once [SIMD is supported](PostMVP.md#fixed-width-simd) WebAssembly would:
 Once [GC is supported](GC.md), WebAssembly code would be able to reference
 and access JavaScript, DOM, and general WebIDL-defined objects.
 
-  [CORS]: https://www.w3.org/TR/cors/
+  [same-origin policy]: https://www.w3.org/Security/wiki/Same_Origin_Policy
+  [cross-origin resource sharing (CORS)]: https://www.w3.org/TR/cors/
   [subresource integrity]: https://www.w3.org/TR/SRI/
   [SIMD.js-in-asm.js]: http://discourse.specifiction.org/t/request-for-comments-simd-js-in-asm-js


### PR DESCRIPTION
This commit introduces a discussion of WebAssembly's security model
for both users and developers, though primarily targeted at latter.
Resolves #205.