### PR TITLE
Remove special case for empty-string export_name in JS.md

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -151,10 +151,8 @@ For each [`import`](https://github.com/WebAssembly/spec/blob/master/ml-proto/spe
 function, global, memory and table imports):
 * Let `v` be the resultant value of performing
   [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`importObject`, [`i.module_name`](https://github.com/WebAssembly/spec/blob/master/ml-proto/spec/kernel.ml#L139)).
-* If [`i.export_name`](https://github.com/WebAssembly/spec/blob/master/ml-proto/spec/kernel.ml#L140)
-  is not the empty string:
-  * If `Type(v)` is not Object, throw a `TypeError`.
-  * Let `v` instead be the value of performing [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`v`, `i.export_name`)
+* If `Type(v)` is not Object, throw a `TypeError`.
+* Let `v` be the value of performing [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`v`, `i.export_name`)
 * If `i` is a function import:
   * If `IsCallable(v)` is `false`, throw a `TypeError`.
   * Otherwise, append an anonymous function to `imports` 


### PR DESCRIPTION
In #659 a special-case was added to JS.md for imports with the intention of mimicking ES6 module's "default" import/export and asm.js imports/exports by having the "" export name mean "the default export".  For example, while the import
```
(import "foo" "bar")
```
would require an import object of the form `{foo: {bar: () => {}}}`, as a special case, the import
```
(import "foo" "")
```
requires an import object of the form `{foo: () => {}}`.

The intention was to also have exports do the symmetric thing, however, specifying the exports object as a [namespace object](https://tc39.github.io/ecma262/#sec-module-namespace-exotic-objects) prevents this, such that an export named "" would simply be a property with the empty-string name (`instance.exports[""]`).

This is obviously asymmetric and will cause a mismatch if a ""-named wasm export object is passed to a wasm import.  It also will cause a collision with the otherwise-valid JS property name "".  This seems obviously bad, so this PR removes the special case.

(If we *did* want ES6 default-export behavior, we could assign a non-utf8 byte pattern without colliding with valid names.  But that could be added later, probably post-MVP, if at all.)

