### PR TITLE
Rework f64.min and f64.max for 0.0 and -0.0.

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -579,7 +579,7 @@ follows:
   * `f64.min`: minimum (binary operator); if either operand is NaN, returns NaN
   * `f64.max`: maximum (binary operator); if either operand is NaN, returns NaN
 
-`min` and `max` operators treat `-0.0` as being effectively less than `0.0`.
+`min` and `max` operators return the first operand if the operands are `0.0` and `-0.0`.
 
 In floating point comparisons, the operands are *unordered* if either operand
 is NaN, and *ordered* otherwise.


### PR DESCRIPTION
This PR proposes that if the operands of f64.min or f64.max are `0.0` and `-0.0`, then the first operand is returned. Thereby it is not necessary for the implementations of f64.min and f64.max to distinguish between `0.0` and `-0.0`.