### PR TITLE
Use LEB for br_table

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -461,9 +461,9 @@ The `br_table` operator has an immediate operand which is encoded as follows:
 | Field | Type | Description |
 | ---- | ---- | ---- |
 | arity | `varuint1` | number of arguments |
-| target_count | `varuint32` | number of targets in the target_table |
-| target_table | `uint32*` | target entries that indicate an outer block or loop to which to break |
-| default_target | `uint32` | an outer block or loop to which to break in the default case |
+| target_count | `varuint32` | number of entries in the target_table |
+| target_table | `varuint32*` | target entries that indicate an outer block or loop to which to break |
+| default_target | `varuint32` | an outer block or loop to which to break in the default case |
 
 The `br_table` operator implements an indirect branch. It accepts an optional value argument
 (like other branches) and an additional `i32` expression as input, and 


### PR DESCRIPTION
(Rebasing onto binary_0xC branch--#735 was accidentally based on master)

A very significant portion of the AngryBots and BananaBread demo binaries is taken by br_table opcodes. In fact, in both of these binaries, the total space consumed by br_table is more than br and br_if combined. This PR proposes using LEBs in the encoding of br_table. LEBs are more space-efficient than uint32 for the very common case of br_table target entries being smaller than 4 bytes, and they are more consistent with the rest of the format.

A possible followup would be require the length of the entire br_table as an immediate as well, to allow for bytecode iterators to skip ahead without decoding the entire table.