### PR TITLE
Use section codes instead of section names

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -123,7 +123,7 @@ Known sections have negative ids, while user-defined sections have positive ids 
 the length of a string identifier immediately to follow.
 After the section identification, the section length and data follow.
 All sections unknown to the WebAssembly implementation are ignored.
-A validation error user-defined sections does not cause validation for the whole module to fail and is
+A validation error in a user-defined section does not cause validation for the whole module to fail and is
 instead treated as if the section was absent.
 
 | Field | Type | Description |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -119,12 +119,15 @@ The module starts with a preamble of two fields:
 
 The module preamble is followed by a sequence of sections.
 Each section is identified by a 1-byte *section code* that encodes either a known section or a user-defined section.
-Known sections have non-zero ids, while unkown sections simply have a zero id and are ignored by the WebAssembly implementation.
+Known sections have non-zero ids, while unknown sections have a `0` id followed by an identifying string. 
+Unknown sections are ignored by the WebAssembly implementation.
 The section length and data immediately follow the section code.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | id | `varint7` | section code |
+| name_len | `varuint32` ? | length of the section name in bytes, present if `id == 0` |
+| name | `bytes` ? | section name string, present if `id == 0` |
 | payload_len  | `varuint32` | size of this section in bytes |
 | payload_data  | `bytes` | content of this section, of length `payload_len` |
 
@@ -350,7 +353,7 @@ a `data_segment` is:
 User-defined section string: `"name"`
 
 The names section does not change execution semantics, and thus is not allocated a section code.
-It is encoded as an unknown section (id `0`) with the first few payload bytes identifying this section as a string.
+It is encoded as an unknown section (id `0`) followed by the identification string `"name"`.
 Like all unknown sections, a validation error in this section does not cause validation of the module to fail.
 The expectation is that, when a binary WebAssembly module is viewed in a browser or other development
 environment, the names in this section will be used as the names of functions
@@ -358,8 +361,6 @@ and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| name_length | `varint7` | length of the "name" string = 4 |
-| name_string | `bytes` | the literal string "name" of length 4 |
 | count | `varuint32` | count of entries to follow |
 | entries | `function_names*` | sequence of names |
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -124,7 +124,7 @@ The section length and data immediately follow the section code.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| id | `uint8` | section code |
+| id | `varint7` | section code |
 | payload_len  | `varuint32` | size of this section in bytes |
 | payload_data  | `bytes` | content of this section, of length `payload_len` |
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -119,17 +119,19 @@ The module starts with a preamble of two fields:
 
 The module preamble is followed by a sequence of sections.
 Each section is identified by a 1-byte *section code* that encodes either a known section or a user-defined section.
-Known sections have non-zero ids, while unknown sections have a `0` id followed by an identifying string. 
-Unknown sections are ignored by the WebAssembly implementation.
-The section length and data immediately follow the section code.
+The section length and payload data then follow.
+Known sections have non-zero ids, while unknown sections have a `0` id followed by an identifying string as
+part of the payload.
+Unknown sections are ignored by the WebAssembly implementation, and thus validation errors within them do not
+invalidate a module.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | id | `varint7` | section code |
+| payload_len  | `varuint32` | size of this section in bytes |
 | name_len | `varuint32` ? | length of the section name in bytes, present if `id == 0` |
 | name | `bytes` ? | section name string, present if `id == 0` |
-| payload_len  | `varuint32` | size of this section in bytes |
-| payload_data  | `bytes` | content of this section, of length `payload_len` |
+| payload_data  | `bytes` | content of this section, of length `payload_len - sizeof(name) - sizeof(name_len)` |
 
 Each section is optional and may appear at most once.
 Known sections from this list may not appear out of order.

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -123,6 +123,8 @@ Known sections have negative ids, while user-defined sections have positive ids 
 the length of a string identifier immediately to follow.
 After the section identification, the section length and data follow.
 All sections unknown to the WebAssembly implementation are ignored.
+A validation error user-defined sections does not cause validation for the whole module to fail and is
+instead treated as if the section was absent.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
@@ -351,13 +353,12 @@ a `data_segment` is:
 
 ### Name section
 
-Section string: `"name"`
+User-defined section string: `"name"`
 
 The names section does not change execution semantics, and thus is not allocated
 a section opcode.
-A validation error in this section does not cause validation for the whole module to fail and is
-instead treated as if the section was absent. The expectation is that, when a
-binary WebAssembly module is viewed in a browser or other development
+Like all user-defined sections, a validation error in this section does not cause validation of the module to fail.
+The expectation is that, when a binary WebAssembly module is viewed in a browser or other development
 environment, the names in this section will be used as the names of functions
 and locals in the [text format](TextFormat.md).
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -148,7 +148,6 @@ The content of each section is encoded in its `payload_data`.
 | [Code](#code-section) | `-9` | Function bodies (code) |
 | [Element](#element-section) | `-10` | Elements section |
 | [Data](#data-section) | `-11` | Data segments |
-| [Name](#name-section) | `-12`| Names section|
 
 
 The end of the last present section must coincide with the last byte of the
@@ -352,8 +351,11 @@ a `data_segment` is:
 
 ### Name section
 
-The names section does not change execution semantics and a validation error in
-this section does not cause validation for the whole module to fail and is
+Section string: `"name"`
+
+The names section does not change execution semantics, and thus is not allocated
+a section opcode.
+A validation error in this section does not cause validation for the whole module to fail and is
 instead treated as if the section was absent. The expectation is that, when a
 binary WebAssembly module is viewed in a browser or other development
 environment, the names in this section will be used as the names of functions

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -119,22 +119,17 @@ The module starts with a preamble of two fields:
 
 The module preamble is followed by a sequence of sections.
 Each section is identified by a 1-byte *section code* that encodes either a known section or a user-defined section.
-Known sections have non-zero ids, while user-defined sections have a zero id followed by a string identifier.
-The section length and data immediately follow the section identification.
-All sections unknown to the WebAssembly implementation are ignored.
-A validation error in a user-defined section does not cause validation for the whole module to fail and is
-instead treated as if the section was absent.
+Known sections have non-zero ids, while unkown sections simply have a zero id and are ignored by the WebAssembly implementation.
+The section length and data immediately follow the section code.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | id | `uint8` | section code |
-| name_length | `varuint32` ? | length of section name, present if `id == 0` |
-| name |  `bytes` ? | section name string, of length `name_length` bytes, present if `id == 0` |
 | payload_len  | `varuint32` | size of this section in bytes |
 | payload_data  | `bytes` | content of this section, of length `payload_len` |
 
 Each section is optional and may appear at most once.
-Known sections (from this list) may not appear out of order.
+Known sections from this list may not appear out of order.
 The content of each section is encoded in its `payload_data`.
 
 | Section Name | Code | Description |
@@ -354,15 +349,17 @@ a `data_segment` is:
 
 User-defined section string: `"name"`
 
-The names section does not change execution semantics, and thus is not allocated
-a section code.
-Like all user-defined sections, a validation error in this section does not cause validation of the module to fail.
+The names section does not change execution semantics, and thus is not allocated a section code.
+It is encoded as an unknown section (id `0`) with the first few payload bytes identifying this section as a string.
+Like all unknown sections, a validation error in this section does not cause validation of the module to fail.
 The expectation is that, when a binary WebAssembly module is viewed in a browser or other development
 environment, the names in this section will be used as the names of functions
 and locals in the [text format](TextFormat.md).
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
+| name_length | `varint7` | length of the "name" string = 4 |
+| name_string | `bytes` | the literal string "name" of length 4 |
 | count | `varuint32` | count of entries to follow |
 | entries | `function_names*` | sequence of names |
 


### PR DESCRIPTION
(rebasing onto 0xC instead of master)

This PR proposes uses section codes for known sections, which is more compact and easier to check in a decoder.
It allows for user-defined sections that have string names to be encoded in the same manner as before.
The scheme of using negative numbers proposed here also has the advantage of allowing a single decoder to accept the old (0xB) format and the new (0xC) format for the time being.