### PR TITLE
Update text about signed offsets for memory_immediate

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -523,13 +523,14 @@ The `memory_immediate` type is encoded as follows:
 | Name | Type | Description |
 | ---- | ---- | ---- |
 | flags | `varuint32` | a bitfield which currently contains the alignment in the least significant bits, encoded as `log2(alignment)` |
-| offset | `varuint32` | the value of the offset |
+| offset | `varint32` | the value of the offset |
 
 As implied by the `log2(alignment)` encoding, the alignment must be a power of 2.
 As an additional validation criteria, the alignment must be less or equal to 
 natural alignment. The bits after the
 `log(memory-access-size)` least-significant bits must be set to 0. These bits are reserved for future use
 (e.g., for shared memory ordering requirements).
+The offset is encoded a signed `varint32`, but negative offsets are currently disallowed.
 
 ## Simple operators ([described here](AstSemantics.md#32-bit-integer-operators))
 


### PR DESCRIPTION
Update text to allow signed memory offsets in the encoding but disallow them for validation.