### PR TITLE
Add WebAssembly.validate

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -35,6 +35,19 @@ The following intrinsic objects are added:
 
 ### Function Properties of the `WebAssembly` object
 
+#### `WebAssembly.validate`
+
+The `validate` function has the signature:
+```
+Boolean validate(BufferSource bytes)
+```
+If the given `bytes` argument is not a
+[`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
+then a `TypeError` is thrown.
+
+Otherwise, this function performs *validation* as defined by the WebAssembly
+spec and returns `true` if validation succeeded, `false` if validation failed.
+
 #### `WebAssembly.compile`
 
 The `compile` function has the signature:


### PR DESCRIPTION
This PR adds `WebAssembly.validate` to the JS API in JS.md.  The purpose of `validate` is to provide a flexible way to feature test by asking whether a module containing the opcode, type, section etc in question validates.  `WebAssembly.compile` or the `Module` constructor could also be used for this purpose but:
 1. they're going to be a lot slower since they're attempting to compile a module
 2. if we end up with deferred error reporting (#719) one would also have to *execute* the code in question which adds complexity/cost

This PR proposes:
* that `validate` is synchronous, allowing super-fast queries for what I expect will be mostly tiny modules
* that `validate` return a simple Boolean; fancier "why didn't it succeed" result messages with strings or error codes sound like portability hazards (if they aren't precisely specified) and add unnecessary cost assuming most uses will simply want the boolean result.