### PR TITLE
Change WebAssembly.compile to throw on bad args

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -43,8 +43,7 @@ Promise<WebAssembly.Module> compile(BufferSource bytes)
 ```
 If the given `bytes` argument is not a
 [`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
-the returned `Promise` is [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
-with a `TypeError`.
+a `TypeError` is thrown.
 
 Otherwise, this function starts an asychronous task to compile a `WebAssembly.Module`
 as described in the [`WebAssembly.Module` constructor](#webassemblymodule-constructor).


### PR DESCRIPTION
This is a tiny tweak to the JS API to have `WebAssembly.compile` throw an eager exception, instead of returning a rejected `Promise`, if it is given invalid arguments.  I don't actually know what the general JS API precedent is here, but this seems abstractly a bit cleaner so that you only get a `Promise` if an async task was actually started.