### PR TITLE
Block signatures

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -464,7 +464,6 @@ The `br_table` operator has an immediate operand which is encoded as follows:
 
 | Field | Type | Description |
 | ---- | ---- | ---- |
-| arity | `varuint1` | number of arguments |
 | target_count | `varuint32` | number of entries in the target_table |
 | target_table | `varuint32*` | target entries that indicate an outer block or loop to which to break |
 | default_target | `varuint32` | an outer block or loop to which to break in the default case |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -58,11 +58,11 @@ A single-byte unsigned integer indicating a [value type](AstSemantics.md#types).
 
 ### `inline_signature_type`
 A single-byte unsigned integer indicating a signature. These types are encoded as:
-* `0` indicating a signature with 0 arguments and 0 results.
-* `1` indicating a signature with 0 arguments and 1 result of type `i32`.
-* `2` indicating a signature with 0 arguments and 1 result of type `i64`.
-* `3` indicating a signature with 0 arguments and 1 result of type `f32`.
-* `4` indicating a signature with 0 arguments and 1 result of type `f64`.
+* `0` indicating a signature with 0 results.
+* `1` indicating a signature with 1 result of type `i32`.
+* `2` indicating a signature with 1 result of type `i64`.
+* `3` indicating a signature with 1 result of type `f32`.
+* `4` indicating a signature with 1 result of type `f64`.
 
 ### `external_kind`
 A single-byte unsigned integer indicating the kind of definition being imported or defined:

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -56,6 +56,14 @@ A single-byte unsigned integer indicating a [value type](AstSemantics.md#types).
 * `3` indicating type `f32` 
 * `4` indicating type `f64`
 
+### `inline_signature_type`
+A single-byte unsigned integer indicating a signature. These types are encoded as:
+* `0` indicating a signature with 0 arguments and 0 results.
+* `1` indicating a signature with 0 arguments and 1 result of type `i32`.
+* `2` indicating a signature with 0 arguments and 1 result of type `i64`.
+* `3` indicating a signature with 0 arguments and 1 result of type `f32`.
+* `4` indicating a signature with 0 arguments and 1 result of type `f64`.
+
 ### `external_kind`
 A single-byte unsigned integer indicating the kind of definition being imported or defined:
 * `0` indicating a `Function` [import](Modules.md#imports) or [definition](Modules.md#function-and-code-sections)
@@ -436,20 +444,21 @@ It is legal to have several entries with the same type.
 | Name | Opcode | Immediates | Description |
 | ---- | ---- | ---- | ---- |
 | `unreachable` | `0x00` | | trap immediately |
-| `block` | `0x01` |  | begin a sequence of expressions, the last of which yields a value |
-| `loop` | `0x02` |  | begin a block which can also form control flow loops |
-| `if` | `0x03` | | begin if expression |
+| `block` | `0x01` | sig : `inline_signature_type` | begin a sequence of expressions, yielding 0 or 1 values |
+| `loop` | `0x02` |  sig : `inline_signature_type` | begin a block which can also form control flow loops |
+| `if` | `0x03` | sig : `inline_signature_type` | begin if expression |
 | `else` | `0x04` | | begin else expression of if |
 | `select` | `0x05` | | select one of two values based on condition |
-| `br` | `0x06` | arity : `varuint1`, relative_depth : `varuint32` | break that targets an outer nested block |
-| `br_if` | `0x07` | arity : `varuint1`, relative_depth : `varuint32` | conditional break that targets an outer nested block |
+| `br` | `0x06` | relative_depth : `varuint32` | break that targets an outer nested block |
+| `br_if` | `0x07` | relative_depth : `varuint32` | conditional break that targets an outer nested block |
 | `br_table` | `0x08` | see below | branch table control flow construct |
 | `return` | `0x09` | return zero or one value from this function |
 | `drop` | `0x0b` | | ignore value |
 | `nop` | `0x0a` | | no operation |
 | `end` | `0x0f` | | end a block, loop, or if |
 
-The counts following the break operators specify how many operands are taken as transfer arguments; in the MVP, all these values must be either 0 or 1.
+The _sig_ fields of `block` and `if` operators specify function signatures
+which describe their use of the operand stack.
 
 The `br_table` operator has an immediate operand which is encoded as follows:
 


### PR DESCRIPTION
https://github.com/WebAssembly/design/pull/741 proposed moving the arity immediates from branches to block/if, which has the advantage of giving decoders more information up front, however the arities alone aren't enough for some use cases. This PR implements @MikeHolman's [suggestion](https://github.com/WebAssembly/design/pull/741#issuecomment-237885553) to provide full type information up front.

This proposes a new "block signature" type to the Type section, so `block`/`if` only need a single index immediate to specify their full type, even if they are extended to returning multiple values post-MVP.

This gives us a greater benefit than #741 did at approximately the same code size cost -- one immediate per `block` and `if`. And if code size of the immediates becomes a concern, we can introduce an `if0` (and similar opcodes for future block-like opcodes).

In my experiments, the decode time cost of indirecting into the type table to obtain the signature data was not significant.