### PR TITLE
Move segment and start operations to the end of instantiation in JS.md

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -216,7 +216,8 @@ has been modified so that each export simply has a `name`, `type` and `index`:
     reusing an existing object if one exists for the given function definition,
     otherwise creating a new object given `instance` and `index`.
   * If the `type` is global:
-    * Assert: the global is immutable by MVP validation constraint.
+    * [Assert](https://tc39.github.io/ecma262/#assert): the global is immutable
+      by MVP validation constraint.
     * Let `v` be the global variable's initialized value.
     * Export [`ToJSValue`](#tojsvalue)`(v)`.
   * If the `type` is memory, then export a `WebAssembly.Memory` object, reusing

--- a/JS.md
+++ b/JS.md
@@ -247,7 +247,7 @@ Let `instanceObject` be a new `WebAssembly.Instance` object setting
 `[[Instance]]` to `instance` and `exports` to `moduleNamespace`.
 
 If any of the elements of an [Elements section](Modules.md#elements-section)
-refer to an imported function which is not an
+refers to an imported function which is not an
 [Exported Function Exotic Object](#exported-function-exotic-objects), throw a
 [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
@@ -260,8 +260,8 @@ Apply all Data and Element segments to their respective Memory or Table in the
 order in which they appear in the module. Segments may overlap and, if they do,
 the final value is the last value written in order. Note: there should be no
 errors possible that would cause this operation to fail partway through. After
-this operation completes, elements of `instance` may are now visible and callable
-through imported Tables, even if `start` fails.
+this operation completes, elements of `instance` are visible and callable
+through [imported Tables](Modules.md#imports), even if `start` fails.
 
 If a [`start`](Modules.md#module-start-function) is present, it is evaluated
 given `instance`. Any errors thrown by `start` are propagated to the caller.

--- a/Modules.md
+++ b/Modules.md
@@ -61,7 +61,8 @@ mismatch.
 
 A *global variable import* includes the *value type* and *mutability*
 of the global variable. These fields have the same meaning as in the
-[Global section](#global-section).
+[Global section](#global-section). In the MVP, global variable imports must be
+*immutable*.
 
 A *linear memory import* includes the same set of fields defined in the
 [Linear Memory section](#linear-memory-section): *default flag*, *initial
@@ -115,6 +116,8 @@ The meaning an exported definition is defined by the host environment. However,
 if another WebAssembly instance imports the definition, then both instances
 will share the same definition and the associated state (global variable value,
 linear memory bytes, table elements) is shared.
+
+In the MVP, only *immutable* global variables can be exported.
 
 ## Integration with ES6 modules
 


### PR DESCRIPTION
The way JS.md is currently written, failures can occur after the Elements and/or Data segments have been written to globally-visible (imported) tables/memories and/or after `start` is called.  This sort of partial initialization seems undesirable so this PR moves all the globally-visible operations to the very end so failure makes more sense and you can't end up with partially-written segments.