### PR TITLE
always detach ArrayBuffer on grow

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -393,10 +393,9 @@ Let `ret` be the result of performing a
 
 If `ret` is `-1`, a `WebAssembly.RuntimeError` is thrown.
 
-If `M.[[Memory]].maximum` is `None`, perform
-[`DetachArrayBuffer`](http://tc39.github.io/ecma262/#sec-detacharraybuffer)(`M.[[BufferObject]]`).
+Perform [`DetachArrayBuffer`](http://tc39.github.io/ecma262/#sec-detacharraybuffer)(`M.[[BufferObject]]`).
 
-In either case, assign to `M.[[BufferObject]]` a new `ArrayBuffer` whose
+Assign to `M.[[BufferObject]]` a new `ArrayBuffer` whose
 [[[ArrayBufferData]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
 aliases `M.[[Memory]]` and whose 
 [[[ArrayBufferByteLength]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)


### PR DESCRIPTION
When memory is grown, a new `ArrayBuffer` is created to alias the new, bigger memory.  This is necessary since `ArrayBuffer`s lengths' are immutable(ish, modulo detachment).  So the question is: what happens to the previous buffer?  Right now in JS.md:
* if there is no `max` specified, the previous buffer is detached
* if there is a `max` specified, the previous buffer keeps aliasing the same bytes

The latter case was motivated by thinking forward to when we have threads: shared memory will require `max` (so it can pre-reserve and never do a moving realloc) and the "keep aliasing" semantics avoids what would otherwise be *completely racy detachment*.

However, another option I don't think we considered is to have the "keep aliasing" semantics only apply to *shared* memories and to have all unshared memories detach on grow (regardless of `max`).  I think this would be preferable for a few reasons:
* the "keep aliasing" design gives you two `ArrayBuffer`s aliasing the same memory which doesn't happen anywhere else in JS that I know of and this could break expectations (`SharedArrayBuffer`, OTOH, is entirely designed for having multiple JS objects aliasing the same underlying memory)
* having multiple `ArrayBuffer`s aliasing the same memory ends up requiring an extra GC edge (from the dependents to the owner) which means an extra field or weak map, so an iota more complexity/size