### PR TITLE
type correction and missing close quote

### DIFF
--- a/AstSemantics.md
+++ b/AstSemantics.md
@@ -349,7 +349,7 @@ The `br` and `br_if` constructs express low-level branching.
 Branches may only reference labels defined by an outer *enclosing construct*,
 which can be a `block` (with a label at the `end`), `loop` (with a label at the
 beginning), `if` (with a label at the `end` or `else`), `else` (with a label at
-the `end), or the function body (with a label at the `end`). This means that,
+the `end`), or the function body (with a label at the `end`). This means that,
 for example, references to a `block`'s label can only occur within the
 `block`'s body.
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -116,7 +116,7 @@ invalidate a module.
 
 | Field | Type | Description |
 | ----- |  ----- | ----- |
-| id | `varint7` | section code |
+| id | `varuint7` | section code |
 | payload_len  | `varuint32` | size of this section in bytes |
 | name_len | `varuint32` ? | length of the section name in bytes, present if `id == 0` |
 | name | `bytes` ? | section name string, present if `id == 0` |


### PR DESCRIPTION
Negative section ids no longer play a role. 