### PR TITLE
Remove more references to AST

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -370,8 +370,8 @@ general-purpose use on several of today's popular hardware architectures.
 ## Better feature testing support
 
 The [MVP feature testing situation](FeatureTest.md) could be improved by
-allowing unknown/unsupported AST operators to decode and validate. The runtime
-semantics of these unknown operators could either be to trap or call a
+allowing unknown/unsupported instructions to decode and validate. The runtime
+semantics of these unknown instructions could either be to trap or call a
 same-signature module-defined polyfill function. This feature could provide a
 lighter-weight alternative to load-time polyfilling (approach 2 in
 [FeatureTest.md](FeatureTest.md)), especially if the [specific layer](BinaryEncoding.md)

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -315,7 +315,7 @@ operators the possibility of having side effects.
 Debugging techniques are also important, but they don't necessarily need to be
 in the spec itself. Implementations are welcome (and encouraged) to support
 non-standard execution modes, enabled only from developer tools, such as modes
-with alternate rounding, or evaluation of floating point expressions at greater
+with alternate rounding, or evaluation of floating point operators at greater
 precision, to support [techniques for detecting numerical instability]
 (https://www.cs.berkeley.edu/~wkahan/Mindless.pdf), or modes using alternate
 NaN bitpattern rules, to carry diagnostic information and help developers track
@@ -442,7 +442,7 @@ see [JavaScript's `WebAssembly.Table` API](JS.md#webassemblytable-objects)).
 It would be useful to be able to do everything from within WebAssembly so, e.g.,
 it was possible to write a WebAssembly dynamic loader in WebAssembly. As a
 prerequisite, WebAssembly would need first-class support for 
-[GC references](GC.md) in expressions and locals. Given that, the following
+[GC references](GC.md) on the stack and in locals. Given that, the following
 could be added:
 * `get_table`/`set_table`: get or set the table element at a given dynamic
   index; the got/set value would have a GC reference type

--- a/JS.md
+++ b/JS.md
@@ -66,7 +66,7 @@ asynchronous, background, streaming compilation.
 A `WebAssembly.Module` object represents the stateless result of compiling a
 WebAssembly binary-format module and contains one internal slot:
  * [[Module]] : an [`Ast.module`](https://github.com/WebAssembly/spec/blob/master/ml-proto/spec/ast.ml#L208)
-   which is the spec definition of a validated module AST
+   which is the spec definition of a validated module
 
 ### `WebAssembly.Module` Constructor
 
@@ -82,8 +82,8 @@ If the given `bytes` argument is not a
 a `TypeError` exception is thrown.
 
 Otherwise, this function performs synchronous compilation of the `BufferSource`:
-* The byte range delimited by the `BufferSource` is first logically decoded into
-  an AST according to [BinaryEncoding.md](BinaryEncoding.md) and then validated
+* The byte range delimited by the `BufferSource` is first logically decoded 
+  according to [BinaryEncoding.md](BinaryEncoding.md) and then validated
   according to the rules in [spec/check.ml](https://github.com/WebAssembly/spec/blob/master/ml-proto/spec/check.ml#L325).
 * The spec `string` values inside `Ast.module` are decoded as UTF8 as described in 
   [Web.md](Web.md#names).

--- a/MVP.md
+++ b/MVP.md
@@ -12,14 +12,14 @@ The major design components of the MVP have been broken up into separate
 documents:
 * The distributable, loadable and executable unit of code in WebAssembly
   is called a [module](Modules.md).
-* The behavior of WebAssembly code in a module is specified in terms of an
-  [AST](AstSemantics.md).
+* The behavior of WebAssembly code in a module is specified in terms of 
+  [instructions](AstSemantics.md) for a structured stack machine.
 * The WebAssembly binary format, which is designed to be natively decoded by 
   WebAssembly implementations, is specified as a 
-  [binary serialization](BinaryEncoding.md) of a module's AST.
+  [binary encoding](BinaryEncoding.md) of the module's instructions.
 * The WebAssembly text format, which is designed to be read and written when
   using tools (e.g., assemblers, debuggers, profilers), is specified as a
-  [textual projection](TextFormat.md) of a module's AST.
+  [textual projection](TextFormat.md) of a module's instructions.
 * WebAssembly is designed to be implemented both [by web browsers](Web.md)
   and [completely different execution environments](NonWeb.md).
 * To ease the transition to WebAssembly while native support is still

--- a/MVP.md
+++ b/MVP.md
@@ -16,10 +16,10 @@ documents:
   [instructions](AstSemantics.md) for a structured stack machine.
 * The WebAssembly binary format, which is designed to be natively decoded by 
   WebAssembly implementations, is specified as a 
-  [binary encoding](BinaryEncoding.md) of the module's instructions.
+  [binary encoding](BinaryEncoding.md) of a module's structure and code.
 * The WebAssembly text format, which is designed to be read and written when
   using tools (e.g., assemblers, debuggers, profilers), is specified as a
-  [textual projection](TextFormat.md) of a module's instructions.
+  [textual projection](TextFormat.md) of a module's structure and code.
 * WebAssembly is designed to be implemented both [by web browsers](Web.md)
   and [completely different execution environments](NonWeb.md).
 * To ease the transition to WebAssembly while native support is still

--- a/Rationale.md
+++ b/Rationale.md
@@ -182,7 +182,7 @@ See [#107](https://github.com/WebAssembly/spec/pull/107).
 ## Control Flow
 
 Structured control flow provides simple and size-efficient binary encoding and
-compilation. Any control flow—even irreducible—can be transformed into structured
+compilation. Any control flow--even irreducible--can be transformed into structured
 control flow with the
 [Relooper](https://github.com/kripken/emscripten/raw/master/docs/paper.pdf)
 [algorithm](http://dl.acm.org/citation.cfm?id=2048224&CFID=670868333&CFTOKEN=46181900),
@@ -295,6 +295,8 @@ of an expression with only one immediate use. Control flow instructions can then
 expressions with result values, thus allowing even more opportunities to further reduce
 `set_local`/`get_local` usage (which constitute 30-40% of total bytes in the
 [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1)).
+`br`-with-value and `if` constructs that return values can model also model `phis` which
+appear in SSA representations of programs.
 
 
 ## Limited Local Nondeterminism

--- a/Rationale.md
+++ b/Rationale.md
@@ -36,7 +36,7 @@ Why not an AST, or a register- or SSA-based bytecode?
 The WebAssembly stack machine is restricted to structured control flow and structured
 use of the stack. This greatly simplifies one-pass verification, avoiding a fixpoint computation
 like that of other stack machines such as the Java Virtual Machine.
-This also simplifies compilation and manipulating of WebAssembly code by other tools.
+This also simplifies compilation and manipulation of WebAssembly code by other tools.
 
 ## Basic Types Only
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -18,7 +18,7 @@ and update the [design](AstSemantics.md) before the MVP is finalized.
 Why not an AST, or a register- or SSA-based bytecode?
 
 * We started with an AST and generalized to a (restricted) stack machine. ASTs allow a 
-  dense encoding and (with postorder) an efficient decoding, compilation, and interpretation.
+  dense encoding and efficient decoding, compilation, and interpretation.
   The stack machine is a generalization of ASTs allowed in previous versions while allowing
   efficiency gains in interpretation and baseline compilation, as well as a straightforward 
   design for multi-return functions.

--- a/Rationale.md
+++ b/Rationale.md
@@ -17,7 +17,7 @@ and update the [design](AstSemantics.md) before the MVP is finalized.
 
 Why not an AST, or a register- or SSA-based bytecode?
 
-* We started with an AST and generalized to a (restricted) stack machine. ASTs allow a 
+* We started with an AST and generalized to a [structured stack machine][AstSemantics.md]. ASTs allow a 
   dense encoding and efficient decoding, compilation, and interpretation.
   The stack machine is a generalization of ASTs allowed in previous versions while allowing
   efficiency gains in interpretation and baseline compilation, as well as a straightforward 
@@ -35,8 +35,8 @@ Why not an AST, or a register- or SSA-based bytecode?
 
 The WebAssembly stack machine is restricted to structured control flow and structured
 use of the stack. This greatly simplifies one-pass verification, avoiding a fixpoint computation
-like that of the Java Virtual Machine, as well as compilation and manipulating of
-WebAssembly code by other tools.
+like that of other stack machines such as the Java Virtual Machine.
+This also simplifies compilation and manipulating of WebAssembly code by other tools.
 
 ## Basic Types Only
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -19,11 +19,12 @@ Why not an AST, or a register- or SSA-based bytecode?
 
 * We started with an AST and generalized to a [structured stack machine](AstSemantics.md). ASTs allow a 
   dense encoding and efficient decoding, compilation, and interpretation.
-  The stack machine is a generalization of ASTs allowed in previous versions while allowing
+  The structured stack machine of WebAssembly is a generalization of ASTs allowed in previous versions while allowing
   efficiency gains in interpretation and baseline compilation, as well as a straightforward 
   design for multi-return functions.
-* The stack machine allows smaller binary encoding than registers or SSA, and structured control
-  flow preserves the size advantages of an AST: [JSZap][], [Slim Binaries][].
+* The stack machine allows smaller binary encoding than registers or SSA [JSZap][], [Slim Binaries][],
+  and structured control flow allows simpler and more efficient verification, including decoding directly
+  to a compiler's internal SSA form.
 * [Polyfill prototype][] shows simple and efficient translation to asm.js.
 
   [JSZap]: https://research.microsoft.com/en-us/projects/jszap/
@@ -35,8 +36,10 @@ Why not an AST, or a register- or SSA-based bytecode?
 
 The WebAssembly stack machine is restricted to structured control flow and structured
 use of the stack. This greatly simplifies one-pass verification, avoiding a fixpoint computation
-like that of other stack machines such as the Java Virtual Machine.
+like that of other stack machines such as the Java Virtual Machine (prior to [stack maps](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html)).
 This also simplifies compilation and manipulation of WebAssembly code by other tools.
+Further generalization of the WebAssembly stack machine is planned post-MVP, such as the
+addition of multiple return values from control flow constructs and function calls.
 
 ## Basic Types Only
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -17,7 +17,7 @@ and update the [design](AstSemantics.md) before the MVP is finalized.
 
 Why not an AST, or a register- or SSA-based bytecode?
 
-* We started with an AST and generalized to a [structured stack machine][AstSemantics.md]. ASTs allow a 
+* We started with an AST and generalized to a [structured stack machine](AstSemantics.md). ASTs allow a 
   dense encoding and efficient decoding, compilation, and interpretation.
   The stack machine is a generalization of ASTs allowed in previous versions while allowing
   efficiency gains in interpretation and baseline compilation, as well as a straightforward 

--- a/Rationale.md
+++ b/Rationale.md
@@ -282,17 +282,16 @@ segregating the table per signature to require only a bounds check could be cons
 in the future. Also, if tables are small enough, an engine can internally use per-signature
 tables filled with failure handlers to avoid one check.
 
-## Expressions with Control Flow
+## Control Flow Instructions with Values
 
-Expression trees offer significant size reduction by avoiding the need for
-`set_local`/`get_local` pairs in the common case of an expression with only one
-immediate use. Control flow "statements" are in fact expressions with result
-values, thus allowing even more opportunities to build bigger
-expression trees and further reduce `set_local`/`get_local` usage (which
-constitute 30-40% of total bytes in the
+Control flow instructions such as `br`, `br_if`, `br_table`, `if` and `if-else` can 
+transfer stack values in WebAssembly. These primitives are useful building blocks for 
+WebAssembly producers, e.g. in compiling expression languages. It offers significant 
+size reduction by avoiding the need for `set_local`/`get_local` pairs in the common case 
+of an expression with only one immediate use. Control flow instructions can then model
+expressions with result values, thus allowing even more opportunities to further reduce
+`set_local`/`get_local` usage (which constitute 30-40% of total bytes in the
 [polyfill prototype](https://github.com/WebAssembly/polyfill-prototype-1)).
-Additionally, these primitives are useful building blocks for
-WebAssembly-generators (including the JavaScript polyfill prototype).
 
 
 ## Limited Local Nondeterminism

--- a/Rationale.md
+++ b/Rationale.md
@@ -325,12 +325,11 @@ and local manner. This prevents the entire program from being invalid, as would
 be the case with C++ undefined behavior.
 
 As WebAssembly gets implemented and tested with multiple languages on multiple
-architectures there may be a need to revisit some of the decisions:
+architectures we may revisit some of the design decisions:
 
-* When all relevant hardware implement features the same way then there's no
-  need to add nondeterminism to WebAssembly when realistically there's only one
-  mapping from WebAssembly expression to ISA-specific operators. One such
-  example is floating-point: at a high-level most basic instructions follow
+* When all relevant hardware implements an operation the same way, there's no
+  need for nondeterminism in WebAssembly semantics. One such
+  example is floating-point: at a high-level most operators follow
   IEEE-754 semantics, it is therefore not necessary to specify WebAssembly's
   floating-point operators differently from IEEE-754.
 * When different languages have different expectations then it's unfortunate if


### PR DESCRIPTION
This PR updates several documents to replace the discussion of ASTs with discussion of the structured stack machine design of 0xC.

This is about 1/3rd of the documentation work necessary to bring the design repository up to date. Splitting this up is an attempt to organize the changes into reviewable chunks. For example, this PR didn't touch AstSemantics, BinaryEncoding, or a few other places that refer to "initializer expressions."
