### PR TITLE
Add suggested format for wasm frames in Error.stack 

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -34,8 +34,9 @@ ES-262, implementations *should* include WebAssembly stack frames in
 the generated callstacks. [User-defined sections](BinaryEncoding.md#high-level-structure)
 may arbitrarily affect the displayed stack frames. However, by default, when
 no relevant sections are present:
-* The line number reported for a WebAssembly frame *should* be the offset of the 
-  the trap/call instruction within the module's originally-compiled binary.
+* The line number reported for a WebAssembly frame *should* be a best-effort
+  reconstruction of the offset of the frame's current trapping/calling
+  instruction within the module's originally-compiled binary.
 * The column number reported for WebAssembly frames, if not omitted entirely,
   *should* be 1.
 * When a [Name section](BinaryEncoding.md#name-section) is present, the names

--- a/JS.md
+++ b/JS.md
@@ -38,9 +38,11 @@ no relevant sections are present:
   the trap/call instruction within the module's originally-compiled binary.
 * The column number reported for WebAssembly frames, if not omitted entirely,
   *should* be 1.
-* The function name *should* be generated from the template string literal 
-  `wasm-function[${i}]` where `i` is the index of the function in the module's
-  [Code section](BinaryEncoding.md#code-section).
+* When a [Name section](BinaryEncoding.md#name-section) is present, the names
+  given to functions *should* be used in the callstack. Otherwise, for the `i`th
+  function in a module's [Code section](BinaryEncoding.md#code-section),
+  the name should be generated from the template string literal
+  `wasm-function[${i}]`.
 * The filename *should* be that of the JS caller of the originating `Module`
   constructor call.
 

--- a/JS.md
+++ b/JS.md
@@ -29,6 +29,21 @@ Because JavaScript exceptions can be handled, and JavaScript can continue to
 call WebAssembly exports after a trap has been handled, traps do not, in
 general, prevent future execution.
 
+Even though the `stack` property of JS `Error` objects is not specified by
+ES-262, implementations *should* include WebAssembly stack frames in
+the generated callstacks. [User-defined sections](BinaryEncoding.md#high-level-structure)
+may arbitrarily affect the displayed stack frames. However, by default, when
+no relevant sections are present:
+* The line number reported for a WebAssembly frame *should* be the offset of the 
+  the trap/call instruction within the module's originally-compiled binary.
+* The column number reported for WebAssembly frames, if not omitted entirely,
+  *should* be 1.
+* The function name *should* be generated from the template string literal 
+  `wasm-function[${i}]` where `i` is the index of the function in the module's
+  [Code section](BinaryEncoding.md#code-section).
+* The filename *should* be that of the JS caller of the originating `Module`
+  constructor call.
+
 ## The `WebAssembly` object
 
 The `WebAssembly` object is the initial value of the `WebAssembly` property of


### PR DESCRIPTION
This PR adds some _should_ clauses for wasm frames in `Error.stack` strings.  Based on previous conversations, I think we already agreed for wasm to use bytecode offset as line number.  Happy to bikeshed the default auto-generated function name.
