### PR TITLE
Future-proof type opcodes

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -53,6 +53,8 @@ Note: Currently, the only sizes used are `varint7`, `varint32` and `varint64`.
 
 ## Language Types
 
+Note: All types are represented by negative `varint7` values. This is so that they can coexist in a single space with (positive) indices into the type section, which may be relevant in future extensions of the type system.
+
 ### `value_type`
 A `varint7` indicating a [value type](Semantics.md#types). These types are encoded as:
 * `-0x01` (i.e., the byte `0x7f`) indicating type `i32`

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -55,21 +55,21 @@ Note: Currently, the only sizes used are `varint7`, `varint32` and `varint64`.
 
 ### `value_type`
 A `varint7` indicating a [value type](Semantics.md#types). These types are encoded as:
-* `-0x01` indicating type `i32`
-* `-0x02` indicating type `i64`
-* `-0x03` indicating type `f32`
-* `-0x04` indicating type `f64`
+* `-0x01` (i.e., the byte `0x7f`) indicating type `i32`
+* `-0x02` (i.e., the byte `0x7e`) indicating type `i64`
+* `-0x03` (i.e., the byte `0x7d`) indicating type `f32`
+* `-0x04` (i.e., the byte `0x7c`) indicating type `f64`
 
 ### `block_type`
 A `varint7` indicating a signature. These types are encoded as:
-* `0x00` indicating a signature with 0 results.
+* `-0x40` (i.e., the byte `0x40`) indicating a signature with 0 results.
 * a [`value_type`](#value_type) indicating a signature with a single result
 
 ### `elem_type`
 
 A `varint7` indicating the types of elements in a [table](AstSemantics.md#table).
 In the MVP, only one type is available:
-* `-0x20` indicating [`anyfunc`](AstSemantics.md#table)
+* `-0x10`  (i.e., the byte `0x70`) indicating [`anyfunc`](AstSemantics.md#table)
 
 Note: In the future, other element types may be allowed.
 
@@ -78,7 +78,7 @@ The description of a function signature.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| form | `varint32` | `-0x40`, indicating a function type |
+| form | `varint32` | `-0x20` (i.e., the byte `0x60`) indicating a function type |
 | param_count | `varuint32` | the number of parameters to the function |
 | param_types | `value_type*` | the parameter types of the function |
 | return_count | `varuint1` | the number of results from the function |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -63,7 +63,7 @@ All types are distinguished by a negative `varint7` values that is the first byt
 | `-0x04` (i.e., the byte `0x7c`) | `f64` |
 | `-0x10` (i.e., the byte `0x70`) | `anyfunc` |
 | `-0x20` (i.e., the byte `0x60`) | `func` |
-| `-0x40` (i.e., the byte `0x40`) | pseudo type for representing an ampty `block_type` |
+| `-0x40` (i.e., the byte `0x40`) | pseudo type for representing an empty `block_type` |
 
 Some of these will be followed by additional fields, see below.
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -31,6 +31,8 @@ for a proposal for layer 1 structural compression.
 
 # Data types
 
+## Numbers
+
 ### `uintN`
 An unsigned integer of _N_ bits,
 represented in _N_/8 bytes in [little endian](https://en.wikipedia.org/wiki/Endianness#Little-endian) order.
@@ -49,20 +51,65 @@ represented by _at most_ ceil(_N_/7) bytes that may contain padding `0x80` or `0
 
 Note: Currently, the only sizes used are `varint32` and `varint64`.
 
+## Language Types
+
 ### `value_type`
 A single-byte unsigned integer indicating a [value type](Semantics.md#types). These types are encoded as:
-* `1` indicating type `i32` 
-* `2` indicating type `i64` 
-* `3` indicating type `f32` 
-* `4` indicating type `f64`
+* `-0x01` indicating type `i32`
+* `-0x02` indicating type `i64`
+* `-0x03` indicating type `f32`
+* `-0x04` indicating type `f64`
 
-### `inline_signature_type`
+### `block_type`
 A single-byte unsigned integer indicating a signature. These types are encoded as:
-* `0` indicating a signature with 0 results.
-* `1` indicating a signature with 1 result of type `i32`.
-* `2` indicating a signature with 1 result of type `i64`.
-* `3` indicating a signature with 1 result of type `f32`.
-* `4` indicating a signature with 1 result of type `f64`.
+* `0x00` indicating a signature with 0 results.
+* a [`value_type`](#value_type) indicating a signature with a single result
+
+### `elem_type`
+
+A `varint7` indicating the types of elements in a [table](AstSemantics.md#table).
+In the MVP, only one type is available:
+* `-0x20` indicating [`anyfunc`](AstSemantics.md#table)
+
+Note: In the future, other element types may be allowed.
+
+### `func_type`
+The description of a function signature.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| form | `varint32` | `-0x40`, indicating a function type |
+| param_count | `varuint32` | the number of parameters to the function |
+| param_types | `value_type*` | the parameter types of the function |
+| return_count | `varuint1` | the number of results from the function |
+| return_type | `value_type?` | the result type of the function (if return_count is 1) |
+
+Note: In the future, `return_count` and `return_type` might be generalised to allow multiple values.
+
+### `global_type`
+The description of a global variable.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| content_type | `value_type` | type of the value |
+| mutability | `varuint1` | `0` if immutable, `1` if mutable; must be `0` in the MVP |
+
+### `table_type`
+The description of a table.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| element_type | `elem_type` | the type of elements |
+| limits | `resizable_limits` | see [below](#resizable_limits) |
+
+### `memory_type`
+The description of a memory.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| limits | `resizable_limits` | see [below](#resizable_limits) |
+
+## Other Types
 
 ### `external_kind`
 A single-byte unsigned integer indicating the kind of definition being imported or defined:
@@ -81,8 +128,7 @@ A packed tuple that describes the limits of a
 | initial | `varuint32` | initial length (in units of table elements or wasm pages) |
 | maximum | `varuint32`? | only present if specified by `flags` |
 
-The "flags" field may later be extended to include a flag for sharing (between
-threads).
+Note: In the future, the "flags" field may be extended, e.g., to include a flag for sharing between threads.
 
 ### `init_expr`
 The encoding of an [initializer expression](Modules.md#initializer-expression)
@@ -151,18 +197,9 @@ The type section declares all function signatures that will be used in the modul
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | count | `varuint32` | count of type entries to follow |
-| entries | `type_entry*` | repeated type entries as described below |
+| entries | `func_type*` | repeated type entries as described below |
 
-#### Type entry
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| form | `varuint7` | `0x40`, indicating a function type |
-| param_count | `varuint32` | the number of parameters to the function |
-| param_types | `value_type*` | the parameter types of the function |
-| return_count | `varuint1` | the number of results from the function |
-| return_type | `value_type?` | the result type of the function (if return_count is 1) |
-
-(Note: In the future, this section may contain other forms of type entries as well, which can be distinguished by the `form` field.)
+Note: In the future, this section may contain other forms of type entries as well, which can be distinguished by the `form` field of the type encoding.
 
 ### Import section
 
@@ -186,27 +223,27 @@ Followed by, if the `kind` is `Function`:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| sig_index | `varuint32` | signature index of the import |
+| type | `varuint32` | type index of the function signature |
 
 or, if the `kind` is `Table`:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| element_type | `varuint7` | `0x20`, indicating [`anyfunc`](Semantics.md#table) |
-| | `resizable_limits` | see [above](#resizable_limits) |
+| type | `table_type` | type of the imported table |
 
 or, if the `kind` is `Memory`:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| | `resizable_limits` | see [above](#resizable_limits) |
+| type | `memory_type` | type of the imported memory |
 
 or, if the `kind` is `Global`:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| type | `value_type` | type of the imported global |
-| mutability | `varuint1` | `0` if immutable, `1` if mutable; must be `0` in the MVP |
+| type | `global_type` | type of the imported global |
+
+Note that, in the MVP, only immutable global variables can be imported.
 
 ### Function section
 
@@ -227,11 +264,6 @@ The encoding of a [Table section](Modules.md#table-section):
 | count | `varuint32` | indicating the number of tables defined by the module |
 | entries | `table_type*` | repeated `table_type` entries as described below |
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| element_type | `varuint7` | `0x20`, indicating [`anyfunc`](Semantics.md#table) |
-| | `resizable_limits` | see [above](#resizable_limits) |
-
 In the MVP, the number of tables must be no more than 1.
 
 ### Memory section
@@ -244,10 +276,6 @@ The encoding of a [Memory section](Modules.md#linear-memory-section):
 | ----- |  ----- | ----- |
 | count | `varuint32` | indicating the number of memories defined by the module |
 | entries | `memory_type*` | repeated `memory_type` entries as described below |
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| | `resizable_limits` | see [above](#resizable_limits) |
 
 Note that the initial/maximum fields are specified in units of 
 [WebAssembly pages](Semantics.md#linear-memory).
@@ -270,8 +298,7 @@ and with the given initializer.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| type | `value_type` | type of the variables |
-| mutability | `varuint1` | `0` if immutable, `1` if mutable |
+| type | `global_type` | type of the variables |
 | init | `init_expr` | the initial value of the global |
 
 Note that, in the MVP, only immutable global variables can be exported.

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -49,19 +49,19 @@ where the former two are used for compatibility with potential future extensions
 A [Signed LEB128](https://en.wikipedia.org/wiki/LEB128#Signed_LEB128) variable-length integer, limited to _N_ bits (i.e., the values [-2^(_N_-1), +2^(_N_-1)-1]),
 represented by _at most_ ceil(_N_/7) bytes that may contain padding `0x80` or `0xFF` bytes.
 
-Note: Currently, the only sizes used are `varint32` and `varint64`.
+Note: Currently, the only sizes used are `varint7`, `varint32` and `varint64`.
 
 ## Language Types
 
 ### `value_type`
-A single-byte unsigned integer indicating a [value type](Semantics.md#types). These types are encoded as:
+A `varint7` indicating a [value type](Semantics.md#types). These types are encoded as:
 * `-0x01` indicating type `i32`
 * `-0x02` indicating type `i64`
 * `-0x03` indicating type `f32`
 * `-0x04` indicating type `f64`
 
 ### `block_type`
-A single-byte unsigned integer indicating a signature. These types are encoded as:
+A `varint7` indicating a signature. These types are encoded as:
 * `0x00` indicating a signature with 0 results.
 * a [`value_type`](#value_type) indicating a signature with a single result
 


### PR DESCRIPTION
Post MVP we will likely extend Wasm with a few richer types, e.g., function types for blocks, struct types, or function pointers. That introduces a number of places where types will be given either directly or via reference to the type section.

To make Wasm future-proof for efficiently overlaying both these spaces, this PR changes the existing type constructors to have negative opcodes, such that they are distinguishable from indexed type definitions (which are naturally positive).

For example, this will in the future allow
- generalising block annotations to multiple or function types without requiring escape code hacks,
- defining local variables that have struct type (by reference into the type section),
- defining struct types whose fields are either value types, function (pointers), or other structs,
- if desirable, inlining of function types for uses where currently a type section entry is required.

The PR also cleans up the description of type encodings.