### PR TITLE
Add frontmatter for jekyll site

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -1,3 +1,5 @@
+---
+---
 # Binary Encoding
 
 This document describes the [portable](Portability.md) binary encoding of the WebAssembly modules.

--- a/CAndC++.md
+++ b/CAndC++.md
@@ -1,3 +1,5 @@
+---
+---
 # Guide for C/C++ developers
 
 WebAssembly is being designed to support C and C++ code well, right from

--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -1,3 +1,5 @@
+---
+---
 # Code of Ethics and Professional Conduct
 
 WebAssembly operates under the W3C's

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,3 +1,5 @@
+---
+---
 # Contributing to WebAssembly
 
 WebAssembly is initially designed and implemented by browser vendors who are

--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -1,3 +1,5 @@
+---
+---
 # Dynamic linking
 
 WebAssembly enables load-time and run-time (`dlopen`) dynamic linking in the

--- a/Events.md
+++ b/Events.md
@@ -1,3 +1,5 @@
+---
+---
 ## Past
 
 | Date | Title | Slides | Video | Presenter(s) |

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,5 @@
+---
+---
 # FAQ
 
 ## Why create a new standard when there is already asm.js?

--- a/FeatureTest.md
+++ b/FeatureTest.md
@@ -1,3 +1,5 @@
+---
+---
 See [rationale](Rationale.md#feature-testing---motivating-scenarios) for motivating scenarios.
 
 # Feature Test

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -1,3 +1,5 @@
+---
+---
 # Feature to add after the MVP
 
 These are features that make sense in the context of the

--- a/GC.md
+++ b/GC.md
@@ -1,3 +1,5 @@
+---
+---
 # GC / DOM / Web API Integration
 
 After the [MVP](MVP.md), to realize the [high-level goals](HighLevelGoals.md)

--- a/HighLevelGoals.md
+++ b/HighLevelGoals.md
@@ -1,3 +1,5 @@
+---
+---
 # WebAssembly High-Level Goals
 
 1. Define a [portable](Portability.md), size- and load-time-efficient

--- a/JITLibrary.md
+++ b/JITLibrary.md
@@ -1,3 +1,5 @@
+---
+---
 # JIT and Optimization Library
 
 WebAssembly's

--- a/JS.md
+++ b/JS.md
@@ -1,3 +1,5 @@
+---
+---
 # JavaScript API
 
 In the [MVP](MVP.md), the only way to access WebAssembly on the Web is through

--- a/MVP.md
+++ b/MVP.md
@@ -1,3 +1,5 @@
+---
+---
 # Minimum Viable Product
 
 As stated in the [high-level goals](HighLevelGoals.md), the first release aims

--- a/Modules.md
+++ b/Modules.md
@@ -1,3 +1,5 @@
+---
+---
 # Modules
 
 The distributable, loadable, and executable unit of code in WebAssembly

--- a/NonWeb.md
+++ b/NonWeb.md
@@ -1,3 +1,5 @@
+---
+---
 # Non-Web Embeddings
 
 While WebAssembly is designed to run [on the Web](Web.md), it is

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -1,3 +1,5 @@
+---
+---
 # Nondeterminism in WebAssembly
 
 WebAssembly is a [portable](Portability.md) [sandboxed](Security.md) platform

--- a/Portability.md
+++ b/Portability.md
@@ -1,3 +1,5 @@
+---
+---
 # Portability
 
 WebAssembly's [binary format](BinaryEncoding.md) is designed to be executable

--- a/PostMVP.md
+++ b/PostMVP.md
@@ -1,3 +1,5 @@
+---
+---
 # Essential Post-MVP Features
 
 Some features are known to be essential and needed as soon as possible but aren't

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+---
+---
 # WebAssembly Design
 
 > This repository contains documents describing the design and high-level overview of WebAssembly.

--- a/Rationale.md
+++ b/Rationale.md
@@ -1,3 +1,5 @@
+---
+---
 # Design Rationale
 
 This document describes rationales for WebAssembly's design decisions, acting as

--- a/Security.md
+++ b/Security.md
@@ -1,3 +1,5 @@
+---
+---
 # Security
 
 The security model of WebAssembly has two important goals: (1) protect *users*

--- a/Semantics.md
+++ b/Semantics.md
@@ -1,3 +1,5 @@
+---
+---
 # Semantics
 
 This document explains the high-level design of WebAssembly code: its types, constructs, and

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -1,3 +1,5 @@
+---
+---
 # Text Format
 
 The purpose of this text format is to support:

--- a/Tooling.md
+++ b/Tooling.md
@@ -1,3 +1,5 @@
+---
+---
 # Tooling support
 
 Tooling for in-browser execution is often of uneven quality. WebAssembly aims at

--- a/UseCases.md
+++ b/UseCases.md
@@ -1,3 +1,5 @@
+---
+---
 # Use Cases
 
 WebAssembly's [high-level goals](HighLevelGoals.md) define *what* WebAssembly

--- a/Web.md
+++ b/Web.md
@@ -1,3 +1,5 @@
+---
+---
 # Web Embedding
 
 Unsurprisingly, one of WebAssembly's primary purposes is to run on the Web,


### PR DESCRIPTION
I'm planning to include the `design` repo as a git submodule of the `webassembly.github.io` repo in order to publish the markdown files in this repo as HTML on the WebAssembly site.

In order for the Jekyll static site generator to recognize these files as appropriate content, they must include YAML frontmatter, even if empty.