### PR TITLE
Make markdown more portable

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -71,14 +71,17 @@ Note: Gaps are reserved for future extensions. The use of a signed scheme is so 
 
 ### `value_type`
 A `varint7` indicating a [value type](Semantics.md#types). One of:
+
 * `i32`
 * `i64`
 * `f32`
 * `f64`
+
 as encoded above.
 
 ### `block_type`
 A `varint7` indicating a block signature. These types are encoded as:
+
 * either a [`value_type`](#value_type) indicating a signature with a single result
 * or `-0x40` (i.e., the byte `0x40`) indicating a signature with 0 results.
 
@@ -86,6 +89,7 @@ A `varint7` indicating a block signature. These types are encoded as:
 
 A `varint7` indicating the types of elements in a [table](AstSemantics.md#table).
 In the MVP, only one type is available:
+
 * [`anyfunc`](AstSemantics.md#table)
 
 Note: In the future, other element types may be allowed.
@@ -130,6 +134,7 @@ The description of a memory.
 
 ### `external_kind`
 A single-byte unsigned integer indicating the kind of definition being imported or defined:
+
 * `0` indicating a `Function` [import](Modules.md#imports) or [definition](Modules.md#function-and-code-sections)
 * `1` indicating a `Table` [import](Modules.md#imports) or [definition](Modules.md#table-section)
 * `2` indicating a `Memory` [import](Modules.md#imports) or [definition](Modules.md#linear-memory-section)
@@ -228,6 +233,7 @@ The import section declares all imports that will be used in the module.
 | entries | `import_entry*` | repeated import entries as described below |
 
 #### Import entry
+
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | module_len | `varuint32` | module string length |
@@ -330,6 +336,7 @@ The encoding of the [Export section](Modules.md#exports):
 | entries | `export_entry*` | repeated export entries as described below |
 
 #### Export entry
+
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | field_len | `varuint32` | field name string length |

--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -20,6 +20,7 @@ achieved by having module A export functions, tables and memories that are
 imported by B. A C++ toolchain can expose this functionality by using the
 same function attributes currently used to export/import symbols from
 native DSOs/DLLs:
+
 ```
 #ifdef _WIN32
 #  define EXPORT __declspec(dllexport)
@@ -34,15 +35,19 @@ typedef void (**PF)();
 IMPORT PF imp();
 EXPORT void exp() { (*imp())(); }
 ```
+
 This code would, at a minimum, generate a WebAssembly module with imports for:
+
 * the function `imp`
 * the heap used to perfom the load, when dereferencing the return value of `imp`
 * the table used to perform the pointer-to-function call
 
 and exports for:
+
 * the function `exp`
 
 A more realistic module using libc would have more imports including:
+
 * an immutable `i32` global import for the offset in linear memory to place
   global [data segments](Modules.md#data-section) and later use as a constant
   base address when loading and storing from globals
@@ -57,6 +62,7 @@ toolchain to put implementation-internal names in a separate namespace, avoiding
 the need for `__`-prefix conventions).
 
 To implement run-time dynamic linking (e.g., `dlopen` and `dlsym`):
+
 * `dlopen` would compile and instantiate a new module, storing the compiled
   instance in a host-environment table, returning the index to the caller.
 * `dlsym` would be given this index, pull the instance out of the table,

--- a/Events.md
+++ b/Events.md
@@ -1,4 +1,4 @@
-## Past
+## Past Events
 
 | Date | Title | Slides | Video | Presenter(s) |
 |-----:|-------|:------:|:-----:|--------------|

--- a/FeatureTest.md
+++ b/FeatureTest.md
@@ -13,12 +13,14 @@ like.
 Since some WebAssembly features add operators and all WebAssembly code in a
 module is validated ahead-of-time, the usual JavaScript feature detection
 pattern:
+
 ```
 if (foo)
     foo();
 else
     alternativeToFoo();
 ```
+
 won't work in WebAssembly (if `foo` isn't supported, `foo()` will fail to
 validate).
 
@@ -68,6 +70,7 @@ that one function was an optimized, but feature-dependent, version of another
 function (similar to the
 [`ifunc` attribute](https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Function-Attributes.html#index-g_t_0040code_007bifunc_007d-attribute-2529),
 but without the callback):
+
 ```
 #include <xmmintrin.h>
 void foo(...) {
@@ -85,6 +88,7 @@ void foo_f64x2(...) __attribute__((optimizes("foo","f64x2"))) {
 ...
 foo(...);                 // calls either foo or foo_f64x2
 ```
+
 In this example, the toolchain could emit both `foo` and `foo_f64x2` as
 function definitions in the "specific layer" binary format. The load-time
 polyfill would then replace `foo` with `foo_f64x2` if

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -1,4 +1,4 @@
-# Feature to add after the MVP
+# Features to add after the MVP
 
 These are features that make sense in the context of the
 [high-level goals](HighLevelGoals.md) of WebAssembly but are not considered part
@@ -14,6 +14,7 @@ This is covered in the [tooling](Tooling.md) section.
 ## Finer-grained control over memory
 
 Provide access to safe OS-provided functionality including:
+
 * `map_file(addr, length, Blob, file-offset)`: semantically, this operator
    copies the specified range from `Blob` into the range `[addr, addr+length)`
    (where `addr+length <= memory_size`) but implementations are encouraged
@@ -51,7 +52,7 @@ can allocate noncontiguous virtual address ranges. See the
 
 Some platforms offer support for memory pages as large as 16GiB, which 
 can improve  the efficiency of memory management in some situations. WebAssembly
-may offer programs the option to specify a larger page size than the [default] (Semantics.md#resizing).
+may offer programs the option to specify a larger page size than the [default](Semantics.md#resizing).
 
 ## More expressive control flow
 
@@ -59,11 +60,13 @@ Some types of control flow (especially irreducible and indirect) cannot be
 expressed with maximum efficiency in WebAssembly without patterned output by the
 relooper and [jump-threading](https://en.wikipedia.org/wiki/Jump_threading)
 optimizations in the engine. Target uses for more expressive control flow are:
+
 * Language interpreters, which often use computed-`goto`.
 * Functional language support, where guaranteed tail call optimization is
   expected for correctness and performance.
 
 Options under consideration:
+
 * No action, `while` and `switch` combined with jump-threading are enough.
 * Just add `goto` (direct and indirect).
 * Add new control-flow primitives that address common patterns.
@@ -403,6 +406,7 @@ can begin.
 
 There are two future features that would allow streaming compilation
 of WebAssembly in browsers:
+
 * [ES6 Module integration](Modules.md#integration-with-es6-modules) would allow
   the browser's network layer to feed a stream directly into the engine.
 * The asynchronous [`WebAssembly.compile`](JS.md#wasmcompile) function could be 
@@ -444,6 +448,7 @@ it was possible to write a WebAssembly dynamic loader in WebAssembly. As a
 prerequisite, WebAssembly would need first-class support for 
 [GC references](GC.md) on the stack and in locals. Given that, the following
 could be added:
+
 * `get_table`/`set_table`: get or set the table element at a given dynamic
   index; the got/set value would have a GC reference type
 * `grow_table`: grow the current table (up to the optional maximum), similar to
@@ -453,6 +458,7 @@ could be added:
 Additionally, in the MVP, the only allowed element type of tables is a generic
 "anyfunc" type which simply means the element can be called but there is no
 static signature validation check. This could be improved by allowing:
+
 * functions with a particular signature, allowing wasm generators to use
   multiple homogeneously-typed function tables (instead of a single
   heterogeneous function table) which eliminates the implied dynamic signature

--- a/GC.md
+++ b/GC.md
@@ -3,6 +3,7 @@
 After the [MVP](MVP.md), to realize the [high-level goals](HighLevelGoals.md)
 of (1) integrating well with the existing Web platform and (2) supporting
 languages other than C++, WebAssembly needs to be able to:
+
 * reference DOM and other Web API objects directly from WebAssembly code;
 * call Web APIs (passing primitives or DOM/GC/Web API objects) directly from
   WebAssembly without calling through JavaScript; and
@@ -59,6 +60,7 @@ in a Web environment.
 Using [opaque reference types](GC.md#opaque-reference-types),
 JavaScript values could be made accessible to WebAssembly code through a builtin
 `js` module providing:
+
 * an exported `string` opaque reference type and exported functions
   to allocate, query length, and index `string` values;
 * an exported `object` opaque reference type and exported functions
@@ -81,6 +83,7 @@ Using [opaque reference types](GC.md#opaque-reference-types), it would be
 possible to allow direct access to DOM and Web APIs by mapping their
 [WebIDL](http://www.w3.org/TR/WebIDL) interfaces to WebAssembly builtin module 
 signatures. In particular:
+
 * WebIDL interfaces (like 
   [WebGLRenderingContextBase](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14)
   or [WebGLTexture](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.9))
@@ -110,6 +113,7 @@ would effectively be skipped.
 
 Another important issue is mapping WebIDL values types that aren't simple
 [primitive types](http://www.w3.org/TR/WebIDL/#dfn-primitive-type):
+
 * [Dictionary types](http://www.w3.org/TR/WebIDL/#idl-dictionary)
   would [appear](http://www.w3.org/TR/WebIDL/#es-dictionary) to require
   JavaScript objects but are actually defined as values such that they can
@@ -144,6 +148,7 @@ direct GC allocation and field access from WebAssembly code through
 
 There is a lot of the design left to
 consider for this feature, but a few points of tentative agreement are:
+
 * To avoid baking in a single language's object model, define low-level GC
   primitives (viz., structs and arrays) and allow the source language compiler
   to build up features like virtual dispatch and access control.

--- a/JS.md
+++ b/JS.md
@@ -54,9 +54,11 @@ The following intrinsic objects are added:
 #### `WebAssembly.validate`
 
 The `validate` function has the signature:
+
 ```
 Boolean validate(BufferSource bytes)
 ```
+
 If the given `bytes` argument is not a
 [`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
 then a `TypeError` is thrown.
@@ -67,9 +69,11 @@ specification](https://github.com/WebAssembly/spec/blob/master/interpreter/) and
 #### `WebAssembly.compile`
 
 The `compile` function has the signature:
+
 ```
 Promise<WebAssembly.Module> compile(BufferSource bytes)
 ```
+
 If the given `bytes` argument is not a
 [`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
 the returned `Promise` is [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
@@ -94,15 +98,18 @@ asynchronous, background, streaming compilation.
 
 A `WebAssembly.Module` object represents the stateless result of compiling a
 WebAssembly binary-format module and contains one internal slot:
+
  * [[Module]] : an [`Ast.module`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L176)
    which is the spec definition of a module
 
 ### `WebAssembly.Module` Constructor
 
 The `WebAssembly.Module` constructor has the signature:
+
 ```
 new Module(BufferSource bytes)
 ```
+
 If the NewTarget is `undefined`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 exception is thrown (i.e., this constructor cannot be called as a function without `new`).
 
@@ -112,6 +119,7 @@ a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-t
 exception is thrown.
 
 Otherwise, this function performs synchronous compilation of the `BufferSource`:
+
 * The byte range delimited by the `BufferSource` is first logically decoded 
   according to [BinaryEncoding.md](BinaryEncoding.md) and then validated
   according to the rules in [spec/valid.ml](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/valid.ml#L415).
@@ -143,19 +151,23 @@ A `WebAssembly.Instance` object represents the instantiation of a
 `WebAssembly.Module` into a
 [realm](http://tc39.github.io/ecma262/#sec-code-realms) and has one
 internal slot:
+
 * [[Instance]] : an [`Instance.instance`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L17)
   which is the WebAssembly spec definition of an instance
 
 as well as one plain data property (configurable, writable, enumerable)
 added by the constructor:
+
 * exports : a [Module Namespace Object](http://tc39.github.io/ecma262/#sec-module-namespace-objects)
 
 ### `WebAssembly.Instance` Constructor
 
 The `WebAssembly.Instance` constructor has the signature:
+
 ```
 new Instance(moduleObject [, importObject])
 ```
+
 If the NewTarget is `undefined`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 exception is thrown (i.e., this
 constructor cannot be called as a function without `new`).
@@ -179,6 +191,7 @@ Let `imports` be an initially-empty list of [`external`](https://github.com/WebA
 
 For each [`import`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L168)
 `i` in `module.imports`:
+
 * Let `o` be the resultant value of performing
   [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`importObject`, [`i.module_name`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L170)).
 * If `Type(o)` is not Object, throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
@@ -221,6 +234,7 @@ given `module` and `imports`.
 
 Let `exports` be a list of (string, JS value) pairs that is mapped from 
 each [external](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L24) value `e` in `instance.exports` as follows:
+
 * If `e` is a [closure](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L12) `c`:
   * If there is an [Exported Function Exotic Object](#exported-function-exotic-objects) `func` in `funcs` whose `func.[[Closure]]` equals `c`, then return `func`.
   * (Note: At most one wrapper is created for any closure, so `func` is unique, even if there are multiple occurrances in the list. Moreover, if the item was an import that is already an [Exported Function Exotic Object](#exported-function-exotic-objects), then the original function object will be found. For imports that are regular JS functions, a new wrapper will be created.)
@@ -258,6 +272,7 @@ each [external](https://github.com/WebAssembly/spec/blob/master/interpreter/spec
     * Return `table`.
 
 Note: For the purpose of the above algorithm, two [closure](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L7) values are considered equal if and only if:
+
 * Either they are both WebAssembly functions for the same instance and referring to the same function definition.
 * Or they are identical host functions (i.e., each host function value created from a JavaScript function is considered fresh).
 
@@ -318,20 +333,24 @@ of *Exported Function*
 [Exotic Object](http://tc39.github.io/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots).
 Like [Bound Function](http://tc39.github.io/ecma262/#sec-bound-function-exotic-objects) Exotic Object,
 Exported Functions do not have the normal function internal slots but instead have:
+
  * [[Closure]] : the [closure](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L7)
    representing the function
 
 as well as the internal slots required of all builtin functions:
+
  * [[Prototype]] : [%FunctionPrototype%](http://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects)
  * [[Extensible]] : `true`
  * [[Realm]] : the [current Realm Record](http://tc39.github.io/ecma262/#current-realm)
  * [[ScriptOrModule]] : [`GetActiveScriptOrModule`](http://tc39.github.io/ecma262/#sec-getactivescriptormodule)
 
 Exported Functions also have the following data properties:
+
 * the `length` property is set to the exported function's signature's arity 
 * the `name` is set to `index` as a Number value
 
 WebAssembly Exported Functions have a `[[Call]](this, argValues)` method defined as:
+
  * Let `args` be an empty list of coerced values.
  * Let `inArity` be the number of arguments and `outArity` be the number of results in the [`function type`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/eval.ml#L106) of the function's [[Closure]].
  * For all values `v` in `argValues`, in the order of their appearance:
@@ -352,6 +371,7 @@ call one with the `new` operator.
 A `WebAssembly.Memory` object contains a single [linear memory](Semantics.md#linear-memory)
 which can be simultaneously referenced by multiple `Instance` objects. Each
 `Memory` object has two internal slots:
+
  * [[Memory]] : a [`Memory.memory`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/memory.mli)
  * [[BufferObject]] : the current `ArrayBuffer` whose [[ArrayBufferByteLength]]
    matches the current byte length of [[Memory]]
@@ -359,9 +379,11 @@ which can be simultaneously referenced by multiple `Instance` objects. Each
 ### `WebAssembly.Memory` Constructor
 
 The `WebAssembly.Memory` constructor has the signature:
+
 ```
 new Memory(memoryDescriptor)
 ```
+
 If the NewTarget is `undefined`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 exception is thrown (i.e., this constructor cannot be called as a function without `new`).
 
@@ -398,6 +420,7 @@ Return a new `WebAssembly.Memory` instance with [[Memory]] set to `m` and
 ### `WebAssembly.Memory.prototype.grow`
 
 The `grow` method has the signature:
+
 ```
 grow(delta)
 ```
@@ -436,15 +459,18 @@ is thrown. Otherwise return `M.[[BufferObject]]`.
 A `WebAssembly.Table` object contains a single [table](Semantics.md#table)
 which can be simultaneously referenced by multiple `Instance` objects. Each
 `Table` object has two internal slots:
+
  * [[Table]] : a [`Table.table`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/table.mli#L1)
  * [[Values]] : an array whose elements are either `null` or [Exported Function Exotic Object](#exported-function-exotic-objects)
 
 ### `WebAssembly.Table` Constructor
 
 The `WebAssembly.Table` constructor has the signature:
+
 ```
 new Table(tableDescriptor)
 ```
+
 If the NewTarget is `undefined`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 exception is thrown (i.e., this constructor cannot be called as a function without `new`).
 
@@ -493,9 +519,11 @@ On failure, a [`RangeError`](https://tc39.github.io/ecma262/#sec-native-error-ty
 ### `WebAssembly.Table.prototype.get`
 
 This method has the following signature
+
 ```
 get(index)
 ```
+
 Let `T` be the `this` value. If `T` is not a `WebAssembly.Table`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
@@ -508,6 +536,7 @@ Return `T.[[Values]][i]`.
 ### `WebAssembly.Table.prototype.set`
 
 This method has the following signature
+
 ```
 set(index, value)
 ```
@@ -576,6 +605,7 @@ Return `i`.
 ## Sample API Usage
 
 Given `demo.was` (encoded to `demo.wasm`):
+
 ```lisp
 (module
     (import $i1 "m" "import1")
@@ -586,7 +616,9 @@ Given `demo.was` (encoded to `demo.wasm`):
     (export "f" $f)
 )
 ```
+
 and the following JavaScript, run in a browser:
+
 ```javascript
 fetch('demo.wasm').then(response =>
     response.arrayBuffer()
@@ -603,5 +635,6 @@ fetch('demo.wasm').then(response =>
 ```
 
 ## TODO
+
 * `WebAssembly.Module` `exports`/`imports` properties (reflection)
 * JS API for cyclic imports (perhaps a Promise-returning `WebAssembly.instantiate`?)

--- a/MVP.md
+++ b/MVP.md
@@ -10,6 +10,7 @@ even on mobile devices, which leads to roughly the same functionality as
 
 The major design components of the MVP have been broken up into separate
 documents:
+
 * The distributable, loadable and executable unit of code in WebAssembly
   is called a [module](Modules.md).
 * The behavior of WebAssembly code in a module is specified in terms of 

--- a/Modules.md
+++ b/Modules.md
@@ -9,6 +9,7 @@ module instances can access the same shared state which is the basis for
 are also designed to [integrate with ES6 modules](#integration-with-es6-modules).
 
 A module contains the following sections:
+
 * [import](#imports)
 * [export](#exports)
 * [start](#module-start-function)
@@ -21,6 +22,7 @@ A module contains the following sections:
 
 A module also defines several *index spaces* which are statically indexed by
 various operators and section fields in the module:
+
 * the [function index space](#function-index-space)
 * the [global index space](#global-index-space)
 * the [linear memory index space](#linear-memory-index-space)
@@ -30,6 +32,7 @@ various operators and section fields in the module:
 
 A module can declare a sequence of **imports** which are provided, at
 instantiation time, by the host environment. There are several kinds of imports:
+
 * **function imports**, which can be called inside the module by the
   [`call`](Semantics.md#calls) operator;
 * **global imports**, which can be accessed inside the module by the
@@ -86,6 +89,7 @@ less-or-equal maximum length. In the MVP, every table is a [default table](Seman
 and thus there may be at most one table import or table section.
 
 Since the WebAssembly spec does not define how import names are interpreted:
+
 * the [Web environment](Web.md#names) defines names to be UTF8-encoded strings;
 * the host environment can interpret the module name as a file path, a URL,
   a key in a fixed set of builtin modules or the host environment may invoke a
@@ -123,6 +127,7 @@ define when this parsing/linking/execution occurs. An additional extension
 to the HTML spec is required to say when a script is parsed as a module instead
 of normal global code. This work is [ongoing](https://github.com/whatwg/loader/blob/master/roadmap.md).
 Currently, the following entry points for modules are being considered:
+
 * `<script type="module">`;
 * an overload to the `Worker` constructor;
 * an overload to the `importScripts` Worker API;
@@ -191,6 +196,7 @@ before calling any other module function. In the second case, the environment is
 expected to call the module function indexed 42. This number is the function index starting from 0 (same as for `export`).
 
 A module can:
+
 * Only have at most a start node
 * If a module contains a start node, the function must be defined in the module
 * The start function will be called after module loading and before any call to the module
@@ -277,6 +283,7 @@ by their index into the corresponding [index space](Modules.md).
 ## Function and Code sections
 
 A single logical function definition is defined in two sections: 
+
  * the *function* section declares the signatures of each internal function
    definition in the module;
  * the *code* section contains the [function body](BinaryEncoding.md#function-bodies)
@@ -294,6 +301,7 @@ function definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 
 The function index space is used by:
+
 * [calls](Semantics.md#calls), to identify the callee of a direct call
 
 ## Global Index Space
@@ -303,6 +311,7 @@ global definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 
 The global index space is used by:
+
 * [global variable access operators](Semantics.md#global-variables), to
   identify the global variable to read/write
 * [data segments](#data-section), to define the offset of a data segment
@@ -334,6 +343,7 @@ a placeholder for when there can be
 
 Initializer expressions are evaluated at instantiation time and are currently
 used to:
+
  * define the initial value of [global variables](#global-section)
  * define the offset of a [data segment](#data-section) or 
    [elements segment](#elements-section)
@@ -347,6 +357,7 @@ expressions.
 In the MVP, to keep things simple while still supporting the basic needs
 of [dynamic linking](DynamicLinking.md), initializer expressions are restricted
 to the following nullary operators:
+
  * the four [constant operators](Semantics.md#constants); and
  * `get_global`, where the global index must refer to an immutable import.
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -2,6 +2,7 @@
 
 WebAssembly is a [portable](Portability.md) [sandboxed](Security.md) platform
 with limited, local, nondeterminism.
+
   * *Limited*: nondeterministic execution can only occur in a small number of
     well-defined cases (described below) and, in those cases, the implementation
     may select from a limited set of possible behaviors.

--- a/PostMVP.md
+++ b/PostMVP.md
@@ -47,6 +47,7 @@ operators (no different from `i32.add`) or exports of a builtin SIMD module.
 
 The WebAssembly MVP may support four no-exception
 modes for C++:
+
 * Compiler transforms `throw` to `abort()`.
 * Compiler-enforced `-fno-exceptions` mode (note [caveats][]).
 * Compiler conversion of exceptions to branching at all callsites.

--- a/Rationale.md
+++ b/Rationale.md
@@ -143,6 +143,7 @@ information without significant extra effort.
 
 The [optional maximum size](Modules.md#linear-memory-section) is designed to
 address a number of competing constraints:
+
 1. Allow WebAssembly modules to grab large regions of contiguous memory in a
    32-bit address space early in an application's startup before the virtual
    address space becomes fragmented by execution of the application.
@@ -158,6 +159,7 @@ address a number of competing constraints:
    security hazards, and optimization challenges.
 
 The optional maximum addresses these constraints:
+
 * (1) is addressed by specifying a large maximum memory size. Simply setting a
   large *initial* memory size has problems due to (3) and the fact that a
   failure to allocate initial is a fatal error which makes the choice of "how
@@ -198,7 +200,7 @@ may be added in the future.
 ## Nop
 
 The nop operator does not produce a value or cause side effects.
-It is nevertheless useful for compilers and tools, which sometimes need to replace instructions with a ```nop```. Without a ```nop``` instruction, code generators would use alternative *does-nothing* opcode patterns that consume space in a module and may have a runtime cost. Finding an appropriate opcode that does nothing but has the appropriate type for the node's location is nontrivial. The existence of many different ways to encode ```nop``` - often mixed in the same module - would reduce the efficiency of compression algorithms.
+It is nevertheless useful for compilers and tools, which sometimes need to replace instructions with a `nop`. Without a `nop` instruction, code generators would use alternative *does-nothing* opcode patterns that consume space in a module and may have a runtime cost. Finding an appropriate opcode that does nothing but has the appropriate type for the node's location is nontrivial. The existence of many different ways to encode `nop` - often mixed in the same module - would reduce the efficiency of compression algorithms.
 
 
 ## Locals
@@ -459,6 +461,7 @@ consoles or server side have a similar sandboxing mechanism).
 Given that text is so compressible and it is well known that it is hard to beat
 gzipped source, is there any win from having a binary format over a text format?
 Yes:
+
 * Large reductions in payload size can still significantly decrease the
   compressed file size.
   * Experimental results from a

--- a/Security.md
+++ b/Security.md
@@ -9,6 +9,7 @@ constraints of (1).
 
 Each WebAssembly module executes within a sandboxed environment separated from
 the host runtime using fault isolation techniques. This implies:
+
   * Applications execute independently, and can't escape the sandbox without
   going through appropriate APIs.
   * Applications generally execute deterministically
@@ -30,6 +31,7 @@ at load time, even when [dynamic linking](DynamicLinking.md) is used. This
 allows implicit enforcement of [control-flow integrity][] (CFI) through
 structured control-flow. Since compiled code is immutable and not observable at
 runtime, WebAssembly programs are protected from control flow hijacking attacks.
+
   * [Function calls](Semantics.md#calls) must specify the index of a target
   that corresponds to a valid entry in the
   [function index space](Modules.md#function-index-space) or
@@ -64,6 +66,7 @@ signal abnormal behavior to the execution environment. In a browser, this is
 represented as a JavaScript exception. Support for
 [module-defined trap handlers](FutureFeatures.md#trappingor-non-trapping-strategies)
 will be implemented in the future. Operations that can trap include:
+
   * specifying an invalid index in any index space,
   * performing an indirect function call with a mismatched signature,
   * exceeding the maximum size of the protected call stack,

--- a/Semantics.md
+++ b/Semantics.md
@@ -271,6 +271,7 @@ imported or defined internally.
 In the MVP, the primary purpose of tables is to implement indirect function
 calls in C/C++ using an integer index as the pointer-to-function and the table
 to hold the array of indirectly-callable functions. Thus, in the MVP:
+
 * tables may only be accessed from WebAssembly code via [`call_indirect`](#calls);
 * the only allowed table element type is `anyfunc` (function with any signature);
 * tables may not be directly mutated or resized from WebAssembly code;

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -1,6 +1,7 @@
 # Text Format
 
 The purpose of this text format is to support:
+
 * View Source on a WebAssembly module, thus fitting into the Web (where every
   source can be viewed) in a natural way.
 * Presentation in browser development tools when source maps aren't present
@@ -11,6 +12,7 @@ The purpose of this text format is to support:
 The text format is equivalent and isomorphic to the [binary format](BinaryEncoding.md).
 
 The text format will be standardized, but only for tooling purposes:
+
 * Compilers will support this format for `.S` and inline assembly.
 * Debuggers and profilers will present binary code using this textual format.
 * Browsers will not parse the textual format on regular web content in order to

--- a/Tooling.md
+++ b/Tooling.md
@@ -4,6 +4,7 @@ Tooling for in-browser execution is often of uneven quality. WebAssembly aims at
 making it possible to support truly great tooling by exposing
 [low-level capabilities][] instead of prescribing which tooling should be
 built. This enables:
+
 * Porting of existing and familiar tooling to WebAssembly;
 * Building new tooling that's particularly well suited to WebAssembly.
 
@@ -16,6 +17,7 @@ expectations on tooling means WebAssembly has the features required to build
 rich applications for non-developers.
 
 The tooling we expect to support includes:
+
 * Editors:
   - Editors such as vim and emacs should *just work*.
 * Compilers and language virtual machines:

--- a/Web.md
+++ b/Web.md
@@ -66,6 +66,7 @@ distribution networks and to implement [dynamic linking](DynamicLinking.md).
 ## SIMD
 
 Once [SIMD is supported](PostMVP.md#fixed-width-simd) WebAssembly would:
+
 * Be statically typed analogous to [SIMD.js-in-asm.js][];
 * Reuse specification of operation semantics (with TC39);
 * Reuse backend implementation (same IR nodes).


### PR DESCRIPTION
This PR fixes a few typos and re-spaces markdown blocks (primarily lists and code blocks).

While GitHub renders correct HTML before this change, this PR changes to allows [other markdown renderers](http://johnmacfarlane.net/babelmark2/?text=Last+paragraph%0A-+New+list) to also produce correct HTML.

In the future, we should include a CI linter that ensures updates follow a single syntax.

cc frequent contributors for an FYI about spacing lists/code blocks @jfbastien @sunfishcode @lukewagner @titzer @MikeHolman @kripken @dschuff @rossberg-chromium 