### PR TITLE
Fix broken links.

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -82,10 +82,9 @@ expected to be defined in accompaniment.
 
 WebAssembly doesn't change the C or C++ languages. Things which cause
 undefined behavior in C or C++ are still bugs when compiling for WebAssembly
-[even when the corresponding behavior in WebAssembly itself is defined]
-(Nondeterminism.md#note-for-users-of-c-c-and-similar-languages). C and C++
-optimizers still assume that undefined behavior won't occur, so such bugs
-can still lead to surprising behavior.
+[even when the corresponding behavior in WebAssembly itself is defined](Nondeterminism.md#note-for-users-of-c-c-and-similar-languages).
+C and C++ optimizers still assume that undefined behavior won't occur,
+so such bugs can still lead to surprising behavior.
 
 For example, while unaligned memory access is
 [fully defined](Semantics.md#alignment) in WebAssembly, C and C++ compilers
@@ -115,8 +114,7 @@ Most implementation-defined behavior in C and C++ is dependent on the compiler
 rather than on the underlying platform. For those details that are dependent
 on the platform, on WebAssembly they follow naturally from having 8-bit bytes,
 32-bit and 64-bit two's complement integers, and
-[32-bit and 64-bit IEEE-754-2008-style floating point support]
-(Semantics.md#floating-point-operators).
+[32-bit and 64-bit IEEE-754-2008-style floating point support](Semantics.md#floating-point-operators).
 
 ## Portability of compiled code
 

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -411,10 +411,9 @@ Debugging techniques are also important, but they don't necessarily need to be
 in the spec itself. Implementations are welcome (and encouraged) to support
 non-standard execution modes, enabled only from developer tools, such as modes
 with alternate rounding, or evaluation of floating point operators at greater
-precision, to support [techniques for detecting numerical instability]
-(https://www.cs.berkeley.edu/~wkahan/Mindless.pdf), or modes using alternate
-NaN bitpattern rules, to carry diagnostic information and help developers track
-down the sources of NaNs.
+precision, to support [techniques for detecting numerical instability](https://www.cs.berkeley.edu/~wkahan/Mindless.pdf),
+or modes using alternate NaN bitpattern rules, to carry diagnostic information
+and help developers track down the sources of NaNs.
 
 To help developers find the sources of floating point exceptions,
 implementations may wish to provide a mode where NaN values are produced with


### PR DESCRIPTION
The Markdown parser used on the http://webassembly.org/ website doesn't support having a newline character between the [] and () parts of the Markdown link syntax. E.g.:

[![image](https://cloud.githubusercontent.com/assets/1924134/19880749/25c48aa0-9fbd-11e6-8b23-2a1e5097df48.png)](http://webassembly.org/docs/c-and-c++/)

Remove that newline character in order for links to render properly on the website.

As I understand it, the http://webassembly.org/ website is generated in https://github.com/WebAssembly/website repo, which has a git submodule of this repo, that's why I'm doing the change in this repo. First time contributing here, so please let me know if I'm doing something wrong.