### PR TITLE
Clarify names section indexing

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -357,7 +357,7 @@ The start section declares the [start function](Modules.md#module-start-function
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| index | `varuint32` | start function index |
+| index | `varuint32` | start [function index](Modules.md#function-index-space) |
 
 ### Element section
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -427,7 +427,7 @@ and locals in the [text format](TextFormat.md).
 | entries | `function_names*` | sequence of names |
 
 The sequence of `function_names` assigns names to the corresponding
-[function index](#function-index-space). (Note: this assigns names to both
+[function index](Modules.md#function-index-space). (Note: this assigns names to both
 imported and module-defined functions.) The count may be greater or less than
 the actual number of functions.
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -427,8 +427,9 @@ and locals in the [text format](TextFormat.md).
 | entries | `function_names*` | sequence of names |
 
 The sequence of `function_names` assigns names to the corresponding
-function index. The count may be greater or less than the actual number of
-functions.
+[function index](#function-index-space). (Note: this assigns names to both
+imported and module-defined functions.) The count may be greater or less than
+the actual number of functions.
 
 #### Function names
 

--- a/Modules.md
+++ b/Modules.md
@@ -300,7 +300,7 @@ The *function index space* indexes all imported and internally-defined
 function definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 Thus, the index space starts at zero with the function imports (if any) followed
-by the functions defined within the module
+by the functions defined within the module.
 
 The function index space is used by:
 
@@ -312,7 +312,7 @@ The *global index space* indexes all imported and internally-defined
 global definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 Thus, the index space starts at zero with the global imports (if any) followed
-by the globals defined within the module
+by the globals defined within the module.
 
 The global index space is used by:
 
@@ -327,7 +327,7 @@ The *linear memory index space* indexes all imported and internally-defined
 linear memory definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 Thus, the index space starts at zero with the memory imports (if any) followed
-by the memories defined within the module
+by the memories defined within the module.
 
 The linear memory index space is only used by the 
 [data section](#data-section). In the MVP, there is at most one linear memory so
@@ -340,7 +340,7 @@ The *table index space* indexes all imported and internally-defined
 table definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
 Thus, the index space starts at zero with the table imports (if any) followed
-by the tables defined within the module
+by the tables defined within the module.
 
 The table index space is only used by the [elements section](#elements-section).
 In the MVP, there is at most one table so this index space is just

--- a/Modules.md
+++ b/Modules.md
@@ -299,6 +299,8 @@ available before compilation begins.
 The *function index space* indexes all imported and internally-defined
 function definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
+Thus, the index space starts at zero with the function imports (if any) followed
+by the functions defined within the module
 
 The function index space is used by:
 
@@ -309,6 +311,8 @@ The function index space is used by:
 The *global index space* indexes all imported and internally-defined
 global definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
+Thus, the index space starts at zero with the global imports (if any) followed
+by the globals defined within the module
 
 The global index space is used by:
 
@@ -322,6 +326,8 @@ The global index space is used by:
 The *linear memory index space* indexes all imported and internally-defined
 linear memory definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
+Thus, the index space starts at zero with the memory imports (if any) followed
+by the memories defined within the module
 
 The linear memory index space is only used by the 
 [data section](#data-section). In the MVP, there is at most one linear memory so
@@ -333,6 +339,8 @@ this index space is just a placeholder for when there can be
 The *table index space* indexes all imported and internally-defined
 table definitions, assigning monotonically-increasing indices based on the
 order of definition in the module (as defined by the [binary encoding](BinaryEncoding.md)).
+Thus, the index space starts at zero with the table imports (if any) followed
+by the tables defined within the module
 
 The table index space is only used by the [elements section](#elements-section).
 In the MVP, there is at most one table so this index space is just


### PR DESCRIPTION
This PR clarifies something that was technically already implied but might have been overlooked: now that function imports are in the function index space, they are named by the Names section.