### PR TITLE
Fix a typo and an error

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -464,7 +464,7 @@ Function bodies consist of a sequence of local variable declarations followed by
 | local_count | `varuint32` | number of local entries |
 | locals | `local_entry*` | local variables |
 | code | `byte*` | bytecode of the function |
-| end | `byte` | `0x0f`, indicating the end of the body |
+| end | `byte` | `0x0b`, indicating the end of the body |
 
 #### Local Entry
 

--- a/TextFormat.md
+++ b/TextFormat.md
@@ -9,7 +9,7 @@ modules.
 
 # Linear bytecode
 
-WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the [sematics](Semantics.md) of the format. 
+WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the [semantics](Semantics.md) of the format. 
 
 Here is an example function illustrated in C++, binary, and text (linear
 assembly bytecode):


### PR DESCRIPTION
Fixed a typo on "semantics"
Fixed an error for the encoding of 'end' in functions