### PR TITLE
Update event talk video link

### DIFF
--- a/Events.md
+++ b/Events.md
@@ -11,7 +11,7 @@
 | September 14th 2016 | WebAssembly: birth of a virtual ISA | | [video](https://www.youtube.com/watch?v=vmzz17JGPHI) | Ben Smith |
 | September 21st 2016 | C++ on the Web: Let's have some serious fun | | [video](https://www.youtube.com/watch?v=jXMtQ2fTl4c) | Dan Gohman |
 | September 22nd 2016 | WebAssembly: high speed at low cost for everyone | [paper](http://www.mlworkshop.org/2016-1.pdf) | | Andreas Rossberg |
-| November 12th 2016 | Chrome Dev Summit Advanced JS performance with V8 and Web Assembly | | [video](https://www.youtube.com/watch?v=PvZdTZ1Nl5o) | Seth Thompson |
+| November 12th 2016 | Chrome Dev Summit Advanced JS performance with V8 and WebAssembly | | [video](https://www.youtube.com/watch?v=PvZdTZ1Nl5o) | Seth Thompson |
 
 
 ## Upcoming

--- a/Events.md
+++ b/Events.md
@@ -11,10 +11,11 @@
 | September 14th 2016 | WebAssembly: birth of a virtual ISA | | [video](https://www.youtube.com/watch?v=vmzz17JGPHI) | Ben Smith |
 | September 21st 2016 | C++ on the Web: Let's have some serious fun | | [video](https://www.youtube.com/watch?v=jXMtQ2fTl4c) | Dan Gohman |
 | September 22nd 2016 | WebAssembly: high speed at low cost for everyone | [paper](http://www.mlworkshop.org/2016-1.pdf) | | Andreas Rossberg |
+| November 12th 2016 | Chrome Dev Summit Advanced JS performance with V8 and Web Assembly | | [video](https://www.youtube.com/watch?v=PvZdTZ1Nl5o) | Seth Thompson |
+
 
 ## Upcoming
 
 | Date | Title | Slides | Video | Presenter(s) |
 |-----:|-------|:------:|:-----:|--------------|
 | October 31st 2016 | VMIL16: WebAssembly from wire to machine code: a view inside V8's implementation | | | Ben L. Titzer |
-| November 11th 2016 | Chrome Dev Summit Advanced JS performance with V8 and Web Assembly | | | Seth Thompson |


### PR DESCRIPTION
In that talk WebAssembly is mentioned almost at the end of the talk

https://youtu.be/PvZdTZ1Nl5o?t=1409

I wonder if worth update the link to that second in specific or leave the original link.