### PR TITLE
Define the exception type for stack overflows

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -9,14 +9,11 @@ any other Web API that loads ES6 modules via URL—as part of
 
 ## Traps
 
-Whenever WebAssembly semantics specify a deterministic [trap](Semantics.md#traps),
-a `WebAssembly.RuntimeError` object is thrown. Whenever the call stack usage
-of WebAssembly exceeds the available call stack space, the same exception is
-thrown as when the call stack usage of JavaScript exceeds the available call
-stack space. WebAssembly code (currently) has no way to catch these exceptions and
-thus the exceptions will necessarily propagate to the enclosing non-WebAssembly
-caller (either the browser or JavaScript) where they are handled like a normal
-JavaScript exceptions.
+Whenever WebAssembly semantics specify a [trap](Semantics.md#traps),
+a `WebAssembly.RuntimeError` object is thrown. WebAssembly code (currently)
+has no way to catch this exception and thus the exception will necessarily
+propagate to the enclosing non-WebAssembly caller (either the browser or
+JavaScript) where it is handled like a normal JavaScript exception.
 
 If WebAssembly calls JavaScript via import and the JavaScript throws an
 exception, the exception is propagated through the WebAssembly activation to the
@@ -25,6 +22,12 @@ enclosing caller.
 Because JavaScript exceptions can be handled, and JavaScript can continue to
 call WebAssembly exports after a trap has been handled, traps do not, in
 general, prevent future execution.
+
+## Stack Overflow
+
+Whenever a [stack overflow](Semantics.md#stack-overflow) is happening in
+WebAssembly code, the same exception is thrown as for a stack overflow in
+JavaScript.
 
 ## The `WebAssembly` object
 

--- a/JS.md
+++ b/JS.md
@@ -9,11 +9,14 @@ any other Web API that loads ES6 modules via URL—as part of
 
 ## Traps
 
-Whenever WebAssembly semantics specify a [trap](Semantics.md#traps),
-a `WebAssembly.RuntimeError` object is thrown. WebAssembly code (currently)
-has no way to catch this exception and thus the exception will necessarily
-propagate to the enclosing non-WebAssembly caller (either the browser or
-JavaScript) where it is handled like a normal JavaScript exception.
+Whenever WebAssembly semantics specify a deterministic [trap](Semantics.md#traps),
+a `WebAssembly.RuntimeError` object is thrown. Whenever the call stack usage
+of WebAssembly exceeds the available call stack space, the same exception is
+thrown as when the call stack usage of JavaScript exceeds the available call
+stack space. WebAssembly code (currently) has no way to catch these exceptions and
+thus the exceptions will necessarily propagate to the enclosing non-WebAssembly
+caller (either the browser or JavaScript) where they are handled like a normal
+JavaScript exceptions.
 
 If WebAssembly calls JavaScript via import and the JavaScript throws an
 exception, the exception is propagated through the WebAssembly activation to the

--- a/Semantics.md
+++ b/Semantics.md
@@ -42,9 +42,13 @@ environment such as a browser, a trap results in throwing a JavaScript exception
 If developer tools are active, attaching a debugger before the
 termination would be sensible.
 
+## Stack Overflow
+
 Call stack space is limited by unspecified and dynamically varying constraints
 and is a source of [nondeterminism](Nondeterminism.md). If program call stack usage
-exceeds the available call stack space at any time, a trap occurs.
+exceeds the available call stack space at any time, the execution in the
+WebAssembly instance is terminated and abnormal termination is reported to the
+outside environment.
 
 Implementations must have an internal maximum call stack size, and every call
 must take up some resources toward exhausting that size (of course, dynamic


### PR DESCRIPTION
This pull request explicitly defines the exception thrown in JavaScript for WebAssembly stack overflows. The changes were discussed in #867.