### PR TITLE
Add Module.sections

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -177,11 +177,11 @@ The module starts with a preamble of two fields:
 | version | `uint32` | Version number, currently 0xd. The version for MVP will be reset to 1. |
 
 The module preamble is followed by a sequence of sections.
-Each section is identified by a 1-byte *section code* that encodes either a known section or a user-defined section.
+Each section is identified by a 1-byte *section code* that encodes either a known section or a custom section.
 The section length and payload data then follow.
-Known sections have non-zero ids, while unknown sections have a `0` id followed by an identifying string as
+Known sections have non-zero ids, while custom sections have a `0` id followed by an identifying string as
 part of the payload.
-Unknown sections are ignored by the WebAssembly implementation, and thus validation errors within them do not
+Custom sections are ignored by the WebAssembly implementation, and thus validation errors within them do not
 invalidate a module.
 
 | Field | Type | Description |
@@ -193,7 +193,7 @@ invalidate a module.
 | payload_data  | `bytes` | content of this section, of length `payload_len - sizeof(name) - sizeof(name_len)` |
 
 Each known section is optional and may appear at most once.
-Unknown sections all have the same `id`, and can be named non-uniquely (all bytes composing their names can be identical).
+Custom sections all have the same `id`, and can be named non-uniquely (all bytes composing their names can be identical).
 Known sections from this list may not appear out of order.
 The content of each section is encoded in its `payload_data`.
 
@@ -413,11 +413,11 @@ a `data_segment` is:
 
 ### Name section
 
-User-defined section string: `"name"`
+Custom section `name` field: `"name"`
 
-The names section does not change execution semantics, and thus is not allocated a section code.
-It is encoded as an unknown section (id `0`) followed by the identification string `"name"`.
-Like all unknown sections, a validation error in this section does not cause validation of the module to fail.
+The names section is a [custom section](#high-level-structure). 
+It is therefore encoded with id `0` followed by the name string `"name"`.
+Like all custom sections, a validation error in this section does not cause validation of the module to fail.
 The name section may appear only once, and only after the [Data section](#Data-section).
 The expectation is that, when a binary WebAssembly module is viewed in a browser or other development
 environment, the names in this section will be used as the names of functions

--- a/JS.md
+++ b/JS.md
@@ -205,12 +205,12 @@ to the Object `{ module: String(i.module_name), name: String(i.item_name), kind:
 
 Note: other fields like `signature` may be added in the future.
 
-### `WebAssembly.Module.sections`
+### `WebAssembly.Module.userSections`
 
-The `sections` function has the signature:
+The `userSections` function has the signature:
 
 ```
-Array sections(modueObject, sectionName)
+Array userSections(modueObject, sectionName)
 ```
 
 If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)

--- a/JS.md
+++ b/JS.md
@@ -221,8 +221,8 @@ Let `sectionNameString` be the result of [`ToString`](https://tc39.github.io/ecm
 This function returns an `Array` produced by mapping each
 [user-defined section](BinaryEncoding.md#high-level-structure) (i.e., section with
 `id` 0) whose `name` field ([decoded as UTF-8](Web.md#names)) is equal to
-`sectionNameString` to an `ArrayBuffer` containing the section's `payload_data`.
-(Note: `payload_data` does not include `name` or `name_len`.)
+`sectionNameString` to an `ArrayBuffer` containing a copy of the section's
+`payload_data`. (Note: `payload_data` does not include `name` or `name_len`.)
 
 ### Structured Clone of a `WebAssembly.Module`
 

--- a/JS.md
+++ b/JS.md
@@ -216,13 +216,12 @@ Array userSections(modueObject, sectionName)
 If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
-If `Type(sectionName)` is not String, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
-is thrown.
+Let `sectionNameString` be the result of [`ToString`](https://tc39.github.io/ecma262/#sec-tostring)(`sectionName`).
 
 This function returns an `Array` produced by mapping each
 [user-defined section](BinaryEncoding.md#high-level-structure) (i.e., section with
 `id` 0) whose `name` field ([decoded as UTF-8](Web.md#names)) is equal to
-`sectionName` to an `ArrayBuffer` containing the section's `payload_data`.
+`sectionNameString` to an `ArrayBuffer` containing the section's `payload_data`.
 (Note: `payload_data` does not include `name` or `name_len`.)
 
 ### Structured Clone of a `WebAssembly.Module`

--- a/JS.md
+++ b/JS.md
@@ -205,6 +205,26 @@ to the Object `{ module: String(i.module_name), name: String(i.item_name), kind:
 
 Note: other fields like `signature` may be added in the future.
 
+### `WebAssembly.Module.sections`
+
+The `sections` function has the signature:
+
+```
+Array sections(modueObject, sectionName)
+```
+
+If `moduleObject` is not a `WebAssembly.Module` instance, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+is thrown.
+
+If `Type(sectionName)` is not String, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+is thrown.
+
+This function returns an `Array` produced by mapping each
+[user-defined section](BinaryEncoding.md#high-level-structure) (i.e., section with
+`id` 0) whose `name` field ([decoded as UTF-8](Web.md#names)) is equal to
+`sectionName` to an `ArrayBuffer` containing the section's `payload_data`.
+(Note: `payload_data` does not include `name` or `name_len`.)
+
 ### Structured Clone of a `WebAssembly.Module`
 
 A `WebAssembly.Module` is a

--- a/JS.md
+++ b/JS.md
@@ -174,7 +174,7 @@ The `exports` function has the signature:
 Array exports(moduleObject)
 ```
 
-If `moduleObject` is not a `WebAssembly.Module` instance, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
 This function returns an `Array` produced by mapping each
@@ -193,7 +193,7 @@ The `imports` function has the signature:
 Array imports(moduleObject)
 ```
 
-If `moduleObject` is not a `WebAssembly.Module` instance, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
 This function returns an `Array` produced by mapping each
@@ -213,7 +213,7 @@ The `sections` function has the signature:
 Array sections(modueObject, sectionName)
 ```
 
-If `moduleObject` is not a `WebAssembly.Module` instance, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
 If `Type(sectionName)` is not String, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
@@ -268,7 +268,7 @@ If the NewTarget is `undefined`, a [`TypeError`](https://tc39.github.io/ecma262/
 exception is thrown (i.e., this
 constructor cannot be called as a function without `new`).
 
-If `moduleObject` is not a `WebAssembly.Module` instance, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
 Let `module` be the [`Ast.module`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L176)

--- a/JS.md
+++ b/JS.md
@@ -210,7 +210,7 @@ Note: other fields like `signature` may be added in the future.
 The `userSections` function has the signature:
 
 ```
-Array userSections(modueObject, sectionName)
+Array userSections(moduleObject, sectionName)
 ```
 
 If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)

--- a/JS.md
+++ b/JS.md
@@ -205,12 +205,12 @@ to the Object `{ module: String(i.module_name), name: String(i.item_name), kind:
 
 Note: other fields like `signature` may be added in the future.
 
-### `WebAssembly.Module.userSections`
+### `WebAssembly.Module.customSections`
 
-The `userSections` function has the signature:
+The `customSections` function has the signature:
 
 ```
-Array userSections(moduleObject, sectionName)
+Array customSections(moduleObject, sectionName)
 ```
 
 If `moduleObject` is not a `WebAssembly.Module`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
@@ -219,7 +219,7 @@ is thrown.
 Let `sectionNameString` be the result of [`ToString`](https://tc39.github.io/ecma262/#sec-tostring)(`sectionName`).
 
 This function returns an `Array` produced by mapping each
-[user-defined section](BinaryEncoding.md#high-level-structure) (i.e., section with
+[custom section](BinaryEncoding.md#high-level-structure) (i.e., section with
 `id` 0) whose `name` field ([decoded as UTF-8](Web.md#names)) is equal to
 `sectionNameString` to an `ArrayBuffer` containing a copy of the section's
 `payload_data`. (Note: `payload_data` does not include `name` or `name_len`.)


### PR DESCRIPTION
This PR adds a reflective static `Module` function for returning the contents of user-defined sections.  The intended use case is dynamic linking: after compiling a `Module` which is to be dynamically linked to other instances via shared `Memory`/`Table`, the linker needs metadata to know, e.g., how much space to allocate for global data and `Table` entries (including zero/empty entries, so simply exposing the length of `data` and `elem` sections isn't sufficient).  Providing access to metadata through user-defined sections avoids the need for some out-of-band metadata source or the need to do ad hoc binary decoding at runtime.

Two interesting details:
* this proposal only returns *user-defined* sections (known sections should have separate reflective methods like `exports`/`imports`).  However, by rejecting `sectionName` arguments that aren't already a string, we leave open the possibility of passing Number values in the future to extract known sections
* because sections are not necessarily unique, the function returns a (possibly-empty) array of results when querying a given user-defined section name