### PR TITLE
Throw immediately when calling into or out of JS with i64 arg/ret

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -316,7 +316,7 @@ For each [`import`](https://github.com/WebAssembly/spec/blob/master/interpreter/
 1. If `i` is a global import:
   1. [Assert](https://tc39.github.io/ecma262/#assert): the global is immutable
      by MVP validation constraint.
-  1. If `v` is an `i64` or `Type(v)` is not Number, throw a `WebAssembly.LinkError`.
+  1. If the `global_type` of `i` is `i64` or `Type(v)` is not Number, throw a `WebAssembly.LinkError`.
   1. Append [`ToWebAssemblyValue`](#towebassemblyvalue)`(v)` to `imports`.
 1. If `i` is a memory import:
   1. If `v` is not a [`WebAssembly.Memory` object](#webassemblymemory-objects),

--- a/JS.md
+++ b/JS.md
@@ -307,9 +307,9 @@ For each [`import`](https://github.com/WebAssembly/spec/blob/master/interpreter/
       1. If the signature contains an `i64` (as argument or result), the host
          function immediately throws a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
          when called.
-      1. Otherwise, the host function calls `v` by coercing WebAssembly
-         arguments to JavaScript arguments
-         via [`ToJSValue`](#tojsvalue) and returns the result, if any, by coercing
+      1. Otherwise, the host function calls `v` with an `undefined` receiver
+         and WebAssembly arguments coerced to JavaScript arguments
+         via [`ToJSValue`](#tojsvalue). The result is returned by coercing
          via [`ToWebAssemblyValue`](#towebassemblyvalue).
   1. Append `v` to `funcs`.
   1. Append `closure` to `imports`.


### PR DESCRIPTION
As discussed in #913.