### PR TITLE
Change WebAssembly module file signature

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -169,17 +169,23 @@ The following documents the current prototype format. This format is based on an
 
 ## High-level structure
 
-The module starts with a preamble of two fields:
+The module starts with a preamble of the following eight bytes:
 
-| Field | Type | Description |
-| ----- |  ----- | ----- |
-| magic number | `uint32` |  Magic number `0x6d736100` (i.e., '\0asm') |
-| version | `uint32` | Version number, currently 0xd. The version for MVP will be reset to 1. |
+    00 06 04 77 61 73 6D 0E
 
-The module preamble is followed by a sequence of sections.
+WebAssembly modules consist entirely of a list of *sections*, and these initial
+eight bytes are the first section, which is a *custom* section with a 6-byte 
+payload, consisting of the name "wasm" in ASCII and a version number (0x0E) 
+which, in the MVP, will be reset to 1, i.e.
+
+    00 06 04 77 61 73 6D 01
+
+**Note**: binary version 0xE is identical to 0xD except for the file header, so 
+readers of 0xE can retain compatibility by also accepting the old signature, 
+`00 61 73 6D 0D 00 00 00`.
+
 Each section is identified by a 1-byte *section code* that encodes either a known section or a custom section.
-The section length and payload data then follow.
-Known sections have non-zero ids, while custom sections have a `0` id followed by an identifying string as
+The section length and payload data then follow. Known sections have non-zero ids, while custom sections have a `0` id followed by an identifying string as
 part of the payload.
 Custom sections are ignored by the WebAssembly implementation, and thus validation errors within them do not
 invalidate a module.

--- a/Rationale.md
+++ b/Rationale.md
@@ -506,6 +506,29 @@ Yes:
 * [Existing web standards](https://www.w3.org/TR/PNG/) demonstrate many of
   the advantages of a layered encoding strategy.
 
+
+## Why does the file signature start with `00 06 04 ...`?
+
+The first byte is a control character so that JavaScript modules (which cannot 
+contain control characters) can easily be distinguished from WebAssembly 
+modules.
+
+As mentioned in [BinaryEncoding](BinaryEncoding.md#high-level-structure), the 
+initial three bytes ensure that the initial eight bytes are a valid section 
+(with a payload length of 6 and a name of length 4), so that the file as a whole 
+is just a list of sections. The WebAssembly format may thus be considered an 
+instance an instance of a more general "List Of Sections" or "LOS" format. 
+Because LOS files are just a sequence of sections, LOS files can be 
+concatenated. Concatenation is not a useful operation for WebAssembly modules 
+themselves because the result would not be a valid module most cases, but it 
+might be useful for related formats, such as object files or debug information 
+files defined outside the WebAssembly specification. By convention, the initial 
+three bytes 00 06 04 identify an LOS file, implying that any LOS-based format 
+should choose a 4-byte name for its header section, leaving one byte afterward 
+for a version number.
+
+
+
 [future general]: FutureFeatures.md
 [future flow control]: FutureFeatures.md#more-expressive-control-flow
 [future integers]: FutureFeatures.md#additional-integer-operations


### PR DESCRIPTION
Changes the file signature in BinaryEncoding.md as suggested in #921. This PR also increments the version number to 0xE so that we can talk about 0xE as a shorthand way of to referring to this change, but to minimize disruption, module readers can continue to accept the old signature in addition to the new one.