### PR TITLE
Make it a validation error to have memory operations that would trivially be out of bounds because their (offset + load/store size) exceeds the maximum possible memory size

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -584,6 +584,8 @@ natural alignment. The bits after the
 are reserved for [future :unicorn:][future threads] use
 (e.g., for shared memory ordering requirements).
 
+It is a validation error if `offset + numBytesTouched(load/store) - 1 > 2^32 - 1`. If this condition is true, the load or store is guaranteed to be out of bounds.
+
 The `reserved` immediate to the `current_memory` and `grow_memory` operators is
 for [future :unicorn:][future multiple tables] use and must be 0 in the MVP.
 

--- a/Semantics.md
+++ b/Semantics.md
@@ -174,6 +174,12 @@ the addition of the offset to the address never causes wrapping, so if the
 address for an access is out-of-bounds, the effective address will always also
 be out-of-bounds.
 
+It is a validation error if a load or store has an offset immediate where:
+```
+offset + numBytesTouched(load/store) - 1 > 2^32 - 1
+```
+If this condition is true, the load or store is guaranteed to be out of bounds.
+
 In wasm32, address operands and offset attributes have type `i32`, and linear
 memory sizes are limited to 4 GiB (of course, actual sizes are further limited
 by [available resources](Nondeterminism.md)). In wasm64, address operands and


### PR DESCRIPTION
Relevant discussion here:
https://github.com/WebAssembly/design/issues/929