### PR TITLE
update contributing.md and add issue template, part of #844

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 Please contribute feedback on the overall design of WebAssembly, issues about
 the textual specification, or typos from the docs section of webassembly.org.
 
-For browser issues or tooling bugs, see links at http://webassembly.org/community/feedback/.
+For browser issues or tooling bugs, see links at https://github.com/WebAssembly/website/blob/master/community/feedback.md.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 Please contribute feedback on the overall design of WebAssembly, issues about
 the textual specification, or typos from the docs section of webassembly.org.
 
-For browser issues or tooling bugs, see links at https://github.com/WebAssembly/website/blob/master/community/feedback.md.
+For browser issues or tooling bugs, see links at http://webassembly.org/community/feedback/.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+Please contribute feedback on the overall design of WebAssembly, issues about
+the textual specification, or typos from the docs section of webassembly.org.
+
+For browser issues or tooling bugs, see links at http://webassembly.org/community/feedback/.

--- a/Contributing.md
+++ b/Contributing.md
@@ -2,27 +2,34 @@
 
 WebAssembly is initially designed and implemented by browser vendors who are
 interested in meeting a variety of [use cases](UseCases.md). As design and
-implementation progresses they'll need input and contributions from developers
+implementation progresses they need input and contributions from developers
 interested in using WebAssembly.
 
 Interested in participating? We suggest you start by:
 
 1. Acquainting yourself with the
    [Code of Ethics and Professional Conduct](CodeOfConduct.md).
-2. Reading the [WebAssembly design][].
+2. Reading the WebAssembly [design documents][] and the [developer guide][].
 3. Joining the IRC channel `irc://irc.w3.org:6667/#webassembly`.
+4. Perusing the [roadmap][].
 
-With that background understood and communication set up, feel free to
-[file issues][] in the WebAssembly design repository. Please join the
-[W3C Community Group][] before sending pull requests: it provides the legal
-framework that protects the work in this repository. Make sure you're affiliated
-with your company or organization in the Community Group, if any.
+With that background understood and communication set up, feel free to:
 
-As WebAssembly moves forward we expect to form an official standards body, which
+ - [file issues][] in the WebAssembly design repository
+ - [participate][] in browser implementation and tooling development
+
+Please join the [W3C Community Group][] before sending pull requests: it provides
+the legal framework that protects the work in this repository. Make sure you're 
+affiliated with your company or organization in the Community Group, if any.
+
+As WebAssembly moves forward we will form an official standards body, which
 will have its own contribution process to the specification.
 
 Happy assembly!
 
-  [WebAssembly design]: https://github.com/WebAssembly/design
+  [design documents]: https://github.com/WebAssembly/design
+  [developer guide]: http://webassembly.org/getting-started/developers-guide/
+  [roadmap]: http://webassembly.org/roadmap/
   [file issues]: https://github.com/WebAssembly/design/issues
+  [participate]: http://webassembly.org/community/feedback/
   [W3C Community Group]: https://www.w3.org/community/webassembly/


### PR DESCRIPTION
This change:
- updates `contributing.md` to reference developer's guide, public roadmap, and alternate feedback channels
- adds GitHub issue template