### PR TITLE
Add Node talk to Events list

### DIFF
--- a/Events.md
+++ b/Events.md
@@ -11,6 +11,7 @@
 | September 14th 2016 | WebAssembly: birth of a virtual ISA | | [video](https://www.youtube.com/watch?v=vmzz17JGPHI) | Ben Smith |
 | September 21st 2016 | C++ on the Web: Let's have some serious fun | | [video](https://www.youtube.com/watch?v=jXMtQ2fTl4c) | Dan Gohman |
 | September 22nd 2016 | WebAssembly: high speed at low cost for everyone | [paper](http://www.mlworkshop.org/2016-1.pdf) | | Andreas Rossberg |
+| November 7th 2016 | Empire Node: How Webassembly Will Change the Way You Write Javascript | | [video](https://www.youtube.com/watch?v=kq2HBddiyh0) | Seth Samuel |
 | November 12th 2016 | Chrome Dev Summit Advanced JS performance with V8 and WebAssembly | | [video](https://www.youtube.com/watch?v=PvZdTZ1Nl5o) | Seth Thompson |
 
 


### PR DESCRIPTION
This change was committed to the website repo with https://github.com/WebAssembly/website/pull/59. But it turns out that the source of truth for the Events table is in this repo, so it got clobbered on rebuild.