### PR TITLE
Make Names section extensible

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -436,34 +436,62 @@ The expectation is that, when a binary WebAssembly module is viewed in a browser
 environment, the data in this section will be used as the names of functions
 and locals in the [text format](TextFormat.md).
 
+The name section contains a sequence of name subsections:
+
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| count | `varuint32` | count of entries to follow |
-| entries | `function_names*` | sequence of names |
+| name_type | `varuint7` | code identifying type of name contained in this subsection |
+| name_payload_len | `varuint32` | size of this subsection in bytes |
+| name_payload_data | `bytes` | content of this section, of length `name_payload_len` |
 
-The sequence of `function_names` assigns names to the corresponding
-[function index](Modules.md#function-index-space). (Note: this assigns names to both
-imported and module-defined functions.) The count may differ from the actual number of functions.
+Since name subsections have a given length, unknown or unwanted names can be
+skipped over by an engine. The current list of valid `name_type` codes are:
+
+| Name Type | Code | Description |
+| --------- | ---- | ----------- |
+| [Function](#function-names) | `1` | Assigns names to functions |
+| [Local](#local-names) | `2` | Assigns names to locals in functions |
+
+When present, name subsections must appear in this order and at most once. The
+end of the last subsection must coincide with the last byte of the name
+section to be a well-formed name section.
+
+#### Name List
+
+In any of the subsequent subsections, a `name_list` is encoded as:
+
+| Name Type | Type | Description |
+| --------- | ---- | ----------- |
+| count | `varuint32` | number of `name` in names |
+| names | `name*` | sequence of `name` |
+
+where a `name` is encoded as:
+
+| Name Type | Type | Description |
+| --------- | ---- | ----------- |
+| name_len | `varuint32` | number of bytes in name_str |
+| name_str | `bytes` | UTF8 encoding of the name |
 
 #### Function names
 
+The function names subsection is a `name_list` which assign a name to each
+function by [function index](Modules.md#function-index-space). (Note: this
+assigns names to both imported and module-defined functions.) The count
+may differ from the actual number of functions.
+
+#### Local names
+
+The local names subsection assigns a `name_list` to each function defined inside
+the module according to its index in the [Function section](#function-section).
+(Note: this does not assign names to imports; imports have no locals.) The
+`name_list` for a given function assigns a name to each local. The counts may
+differ from both the number of functions and number of locals in a given
+function.
+
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| fun_name_len | `varuint32` | string length, in bytes |
-| fun_name_str | `bytes` | valid utf8 encoding |
-| local_count | `varuint32` | count of local names to follow |
-| local_names | `local_name*` | sequence of local names |
-
-The sequence of `local_name` assigns names to the corresponding local index. The
-count may differ from the actual number of locals.
-
-#### Local name
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| local_name_len | `varuint32` | string length, in bytes |
-| local_name_str | `bytes` | valid utf8 encoding |
-
+| count | `varuint32` | count of `name_list` in func_locals |
+| func_locals | `name_list*` | sequence of `name_list`, one per function |
 
 # Function Bodies
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -444,8 +444,8 @@ The name section contains a sequence of name subsections:
 | name_payload_len | `varuint32` | size of this subsection in bytes |
 | name_payload_data | `bytes` | content of this section, of length `name_payload_len` |
 
-Since name subsections have a given length, unknown or unwanted names can be
-skipped over by an engine. The current list of valid `name_type` codes are:
+Since name subsections have a given length, unknown or unwanted names types can
+be skipped over by an engine. The current list of valid `name_type` codes are:
 
 | Name Type | Code | Description |
 | --------- | ---- | ----------- |

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -456,42 +456,47 @@ When present, name subsections must appear in this order and at most once. The
 end of the last subsection must coincide with the last byte of the name
 section to be a well-formed name section.
 
-#### Name List
+#### Name Map
 
-In any of the subsequent subsections, a `name_list` is encoded as:
-
-| Name Type | Type | Description |
-| --------- | ---- | ----------- |
-| count | `varuint32` | number of `name` in names |
-| names | `name*` | sequence of `name` |
-
-where a `name` is encoded as:
-
-| Name Type | Type | Description |
-| --------- | ---- | ----------- |
-| name_len | `varuint32` | number of bytes in name_str |
-| name_str | `bytes` | UTF8 encoding of the name |
-
-#### Function names
-
-The function names subsection is a `name_list` which assign a name to each
-function by [function index](Modules.md#function-index-space). (Note: this
-assigns names to both imported and module-defined functions.) The count
-may differ from the actual number of functions.
-
-#### Local names
-
-The local names subsection assigns a `name_list` to each function defined inside
-the module according to its index in the [Function section](#function-section).
-(Note: this does not assign names to imports; imports have no locals.) The
-`name_list` for a given function assigns a name to each local. The counts may
-differ from both the number of functions and number of locals in a given
-function.
+In the following subsections, a `name_map` is encoded as:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| count | `varuint32` | count of `name_list` in func_locals |
-| func_locals | `name_list*` | sequence of `name_list`, one per function |
+| count | `varuint32` | number of `name` in names |
+| names | `name*` | sequence of `name` sorted by index |
+
+where a `name` is encoded as:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| index | `varuint32` | the index which is being named |
+| name_len | `varuint32` | number of bytes in name_str |
+| name_str | `bytes` | binary encoding of the name |
+
+#### Function names
+
+The function names subsection is a `name_map` which assigns names to
+a subset of the [function index space](Modules.md#function-index-space)
+(both imports and module-defined).
+
+#### Local names
+
+The local names subsection assigns `name_map`s to a subset of functions in the
+[function index space](Modules.md#function-index-space) (both imports and
+module-defined). The `name_map` for a given function assigns names to a
+subset of local variable indices.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| count | `varuint32` | count of `local_names` in funcs |
+| funcs | `local_names*` | sequence of `local_names` sorted by index |
+
+where a `local_name` is encoded as:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| index | `varuint32` | the index of the function whose locals are being named |
+| local_map | `name_map` | assignment of names to local indices |
 
 # Function Bodies
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -462,10 +462,10 @@ In the following subsections, a `name_map` is encoded as:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| count | `varuint32` | number of `name` in names |
-| names | `name*` | sequence of `name` sorted by index |
+| count | `varuint32` | number of `naming` in names |
+| names | `naming*` | sequence of `naming` sorted by index |
 
-where a `name` is encoded as:
+where a `naming` is encoded as:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |


### PR DESCRIPTION
This PR is intended as a first step to addressing #750 which is to make the names section extensible so that more kinds of names can be added over time.  While in theory new types of names could be added as new top-level custom sections, that seems a bit messy.  So instead, this PR breaks the names section into *subsections*, each of which has a code, and byte length.

To start simple (and allow a quick, targeted update to tools/engines), this PR doesn't add any new types of names; just reformats function and local names.  Since locals aren't the only thing that could be named inside a function (blocks being the other obvious thing), locals are made their own subsection.