### PR TITLE
Change `validate` to return error messages

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -65,7 +65,7 @@ The following intrinsic objects are added:
 The `validate` function has the signature:
 
 ```
-Boolean validate(BufferSource bytes)
+validate(BufferSource bytes): {ok: Boolean, error: String}
 ```
 
 If the given `bytes` argument is not a
@@ -73,7 +73,11 @@ If the given `bytes` argument is not a
 then a `TypeError` is thrown.
 
 Otherwise, this function performs *validation* as defined by the [WebAssembly
-specification](https://github.com/WebAssembly/spec/blob/master/interpreter/) and returns `true` if validation succeeded, `false` if validation failed.
+specification](https://github.com/WebAssembly/spec/blob/master/interpreter/).
+It returns a plain JavaScript object with a property `ok`
+whose falue is `true` if validation succeeded, and `false` otherwise.
+Furthermore, iff `ok` is `false`, a property `error` is present indicating the cause of failure with an implementation-dependent error message.
+Both properties are configurable, enumerable and writable.
 
 #### `WebAssembly.compile`
 


### PR DESCRIPTION
Following the discussion in #993, this PR changes `WebAssembly.validate` to return an object
```
{ok: Boolean, error?: String}
```
so that users are given a useful cause of failure.

This is a fairly late change, but the current version arguably is broken -- it's difficult to come up with a use case for explicitly calling `validate` but not caring about a diagnostics. For example, the test harness currently invokes full compilation after a failed `validate` just to get a decent error message, which is silly -- and moreover, may run afoul of a possible cap on synchronous compiles. Other users are likely to run into the same issues.