### PR TITLE
Split out compileAndInstantiate from instantiate

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -111,8 +111,7 @@ If neither of the following overloads match, then the returned `Promise` is
 with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 ```
-Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
-  instantiate(BufferSource bytes [, importObject])
+Promise<WebAssembly.Instance> instantiate(BufferSource bytes [, importObject])
 ```
 
 This description applies if the first argument is a 
@@ -123,8 +122,7 @@ from `bytes` as described in the [`WebAssembly.Module` constructor](#webassembly
 and then instantiate the resulting `Module` with `importObject` as described in the
 [`WebAssembly.Instance` constructor](#webassemblyinstance-constructor).
 On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
-with a plain JavaScript object pair `{module, instance}` containing the resulting
-`WebAssembly.Module` and `WebAssembly.Instance`. The 2 properties `module` and `instance` of the returned pair are  configurable, enumerable and writable. 
+with the instance.
 
 On failure, the `Promise` is
 [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
@@ -147,6 +145,37 @@ On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulf
 with the resulting `WebAssembly.Instance` object. On failure, the `Promise` is
 [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
 `WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
+
+#### `WebAssembly.compileAndInstantiate`
+
+The `compileAndInstantiate` function has the signature:
+
+```
+Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
+    compileAndInstantiate(BufferSource bytes [, importObject])
+```
+
+If the given `bytes` argument is not a
+[`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
+the returned `Promise` is [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
+with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
+
+This function starts an asynchronous task that first compiles a `WebAssembly.Module`
+from `bytes` as described in the [`WebAssembly.Module` constructor](#webassemblymodule-constructor)
+and then instantiate the resulting `Module` with `importObject` as described in the
+[`WebAssembly.Instance` constructor](#webassemblyinstance-constructor).
+On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
+with a plain JavaScript object pair `{module, instance}` containing the resulting
+`WebAssembly.Module` and `WebAssembly.Instance`. The 2 properties `module` and
+`instance` of the returned pair are  configurable, enumerable and writable. 
+
+On failure, the `Promise` is
+[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
+`WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
+
+The asynchronous compilation is logically performed on a copy of the state of
+the given `BufferSource` captured during the call to `instantiate`; subsequent mutations
+of the `BufferSource` after `instantiate` return do not affect ongoing compilations.
 
 ## `WebAssembly.Module` Objects
 

--- a/Web.md
+++ b/Web.md
@@ -79,11 +79,9 @@ In Web embeddings, the following overloads are added (in addition to the core
 JS API method of the same name).
 
 ```
-Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
-  instantiate(Response source [, importObject])
+Promise<WebAssembly.Instance> instantiate(Response source [, importObject])
 
-Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
-  instantiate(Promise<Response> source [, importObject])
+Promise<WebAssembly.Instance> instantiate(Promise<Response> source [, importObject])
 ```
 
 Developers can set the argument `source` with either a promise that resolves
@@ -107,11 +105,62 @@ the [`WebAssembly.Module` constructor](#webassemblymodule-constructor)
 and then instantiate the resulting `Module` with `importObject` as described in the
 [`WebAssembly.Instance` constructor](#webassemblyinstance-constructor).
 On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
-with a plain JavaScript object pair `{module, instance}` containing the resulting
-`WebAssembly.Module` and `WebAssembly.Instance`. The 2 properties `module` and `instance` of the returned pair are  configurable, enumerable and writable.
+with the instance.
 
 On failure, the `Promise` is
 [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a
+`WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
+
+The `Promise<Response>` is used as the source of the bytes to compile.
+MIME type information is
+[`extracted`](https://fetch.spec.whatwg.org/#concept-header-extract-mime-type)
+from the `Response`, WebAssembly `source` data must have a MIME type of `application/wasm`,
+extra parameters are not allowed (including empty `application/wasm;`).
+MIME type mismatch or `opaque` response types
+[reject](http://tc39.github.io/ecma262/#sec-rejectpromise) the Promise with a
+`WebAssembly.CompileError`.
+
+#### `WebAssembly.compileAndInstantiate`
+
+:cyclone: Added for milestone 2, developers must feature detect.
+
+In Web embeddings, the following overloads are added (in addition to the core
+JS API method of the same name).
+
+```
+Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
+  compileAndInstantiate(Response source [, importObject])
+
+Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>
+  compileAndInstantiate(Promise<Response> source [, importObject])
+```
+
+Developers can set the argument `source` with either a promise that resolves
+with a
+[`Response`](https://fetch.spec.whatwg.org/#response-class)
+object or a
+[`Response`](https://fetch.spec.whatwg.org/#response-class)
+object (which is automatically cast to a
+promise).
+If when unwrapped that `Promise` is not a `Response` object, then the returned `Promise` is
+[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
+with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
+Renderer-side
+security checks about tainting for cross-origin content are tied to the types
+of filtered responses defined in
+[`Fetch`](https://fetch.spec.whatwg.org/#concept-fetch).
+
+This function starts an asynchronous task that first compiles a `WebAssembly.Module`
+from `bytes` as described in the [`WebAssembly.Module` constructor](#webassemblymodule-constructor)
+and then instantiate the resulting `Module` with `importObject` as described in the
+[`WebAssembly.Instance` constructor](#webassemblyinstance-constructor).
+On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
+with a plain JavaScript object pair `{module, instance}` containing the resulting
+`WebAssembly.Module` and `WebAssembly.Instance`. The 2 properties `module` and
+`instance` of the returned pair are  configurable, enumerable and writable. 
+
+On failure, the `Promise` is
+[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
 `WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
 
 The `Promise<Response>` is used as the source of the bytes to compile.


### PR DESCRIPTION
I think there would be a number of benefits from having `instantiate` *always* return a `Promise<Instance>` and having a separate `compileAndInstantiate` that returns the `Promise<{module,instance}>`.  In this PR, `instantiate` is still able to take all the same things it does now, and thus, this PR is strictly more expressive than the current state.  (It's also a pretty simple change to implement.)

The benefits I see of this PR are:
* `instantiate` is less surprising; `compileAndInstantiate` returning a pair is implied by the name.
* It's easier to teach wasm if `instantiate` is just a sink for all manner of byte-y things that always produces an `Instance`.  I was feeling this acutely while writing MDN docs/tutorials recently.
* With `instantiate`, the engine would know up front that the `Module` won't be needed and that the generated code can't be instantiated multiple times, serialized or shared. This can allow for more efficient compilation, more aggressive specialization and less garbage generated by compilation.
* Resolves awkward design question for `instantiateGroup` (#997): given that this function takes a map of inputs and produces a map of outputs: are the output values `Instance`s or `{module,instance}` pairs? Do we have it depend on the dynamic types of values in the input map?  What if some of the input values are `Module`s and some are not?  Do we instead break symmetry and have it always return a `{module,instance}` pair?  After this PR, the obvious, symmetric thing would be to have both `instantiateGroup` and `compileAndInstantiateGroup` which makes the output type clear.