### PR TITLE
Typo

### DIFF
--- a/Semantics.md
+++ b/Semantics.md
@@ -361,7 +361,7 @@ In practice, outer `block`s can be used to place labels for any given branching
 pattern, except that the nesting restriction makes it impossible to branch into the middle of a loop
 from outside the loop. This limitation ensures by construction that all control flow graphs
 are well-structured as in high-level languages like Java, JavaScript and Go.
-Notice that that a branch to a `block`'s label is  equivalent to a labeled `break` in
+Notice that a branch to a `block`'s label is  equivalent to a labeled `break` in
 high-level languages; branches simply break out of a `block`, and branches to a `loop`
 correspond to a "continue" statement.
 


### PR DESCRIPTION
There was a typo where a word was duplicated twice.

<img width="893" alt="screen shot 2017-03-07 at 1 44 48 pm" src="https://cloud.githubusercontent.com/assets/2770126/23672285/44210626-033c-11e7-8171-d30244d66f2d.png">
