### PR TITLE
WebAssembly.Memory: length, initial, maximum

### DIFF
--- a/JS.md
+++ b/JS.md
@@ -561,8 +561,11 @@ Any attempts to [`detach`](http://tc39.github.io/ecma262/#sec-detacharraybuffer)
 the detachment performed by [`m.grow`](#webassemblymemoryprototypegrow) shall throw a 
 [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 
-Return a new `WebAssembly.Memory` instance with [[Memory]] set to `m` and
-[[BufferObject]] set to `buffer`.
+Return a new `WebAssembly.Memory` instance with
+[[Memory]] set to `m`,
+[[BufferObject]] set to `buffer`,
+[[Initial]] set to `initial`, and
+[[Maximum]] set to `undefined` if `maximum` is `None` or `maximum` otherwise.
 
 ### `WebAssembly.Memory.prototype [ @@toStringTag ]` Property
 

--- a/JS.md
+++ b/JS.md
@@ -619,7 +619,7 @@ accessor function performs the following steps:
 If `this` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown. Otherwise return `M.[[BufferObject]]`.
 
-### `WebAssembly.Memory.prototype.length`
+### `WebAssembly.Memory.prototype.byteLength`
 
 [⚜](#Post-MVP-JavaScript-API)
 

--- a/JS.md
+++ b/JS.md
@@ -510,11 +510,13 @@ call one with the `new` operator.
 
 A `WebAssembly.Memory` object contains a single [linear memory](Semantics.md#linear-memory)
 which can be simultaneously referenced by multiple `Instance` objects. Each
-`Memory` object has two internal slots:
+`Memory` object has four internal slots:
 
  * [[Memory]] : a [`Memory.memory`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/memory.mli)
  * [[BufferObject]] : the current `ArrayBuffer` whose [[ArrayBufferByteLength]]
    matches the current byte length of [[Memory]]
+ * [[Initial]] : the `initial` number of WebAssembly pages
+ * [[Maximum]] : the `maximum` number of WebAssembly pages, or `undefined` if `maximum` is `None`
 
 ### `WebAssembly.Memory` Constructor
 
@@ -607,6 +609,36 @@ accessor function performs the following steps:
 
 If `this` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown. Otherwise return `M.[[BufferObject]]`.
+
+### `WebAssembly.Memory.prototype.length`
+
+This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
+accessor function performs the following steps:
+
+Let `T` be the `this` value. If `T` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+is thrown.
+
+Return `T.[[BufferObject]].[[ArrayBufferByteLength]]`.
+
+### `WebAssembly.Memory.prototype.initial`
+
+This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
+accessor function performs the following steps:
+
+Let `T` be the `this` value. If `T` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+is thrown.
+
+Return `T.[[Initial]]`.
+
+### `WebAssembly.Memory.prototype.maximum`
+
+This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
+accessor function performs the following steps:
+
+Let `T` be the `this` value. If `T` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
+is thrown.
+
+Return `T.[[Maximum]]`.
 
 ## `WebAssembly.Table` Objects
 

--- a/JS.md
+++ b/JS.md
@@ -7,6 +7,14 @@ be loaded and run directly from an HTML `<script type='module'>` tag—and
 any other Web API that loads ES6 modules via URL—as part of 
 [ES6 Module integration](Modules.md#integration-with-es6-modules).)
 
+## Post-MVP JavaScript API
+
+Some JavaScript APIs were added post-MVP and can be
+[feature-tested](FeatureTest.md) together. These are grouped together,
+and each group is denoted with one of the following symbols:
+
+* ⚜
+
 ## Traps
 
 Whenever WebAssembly semantics specify a [trap](Semantics.md#traps),
@@ -613,7 +621,9 @@ accessor function performs the following steps:
 If `this` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown. Otherwise return `M.[[BufferObject]]`.
 
-### `WebAssembly.Memory.prototype.length`
+### `WebAssembly.Memory.prototype.byteLength`
+
+[⚜](#Post-MVP-JavaScript-API)
 
 This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
 accessor function performs the following steps:
@@ -625,6 +635,8 @@ Return `T.[[BufferObject]].[[ArrayBufferByteLength]]`.
 
 ### `WebAssembly.Memory.prototype.initial`
 
+[⚜](#Post-MVP-JavaScript-API)
+
 This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
 accessor function performs the following steps:
 
@@ -634,6 +646,8 @@ is thrown.
 Return `T.[[Initial]]`.
 
 ### `WebAssembly.Memory.prototype.maximum`
+
+[⚜](#Post-MVP-JavaScript-API)
 
 This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
 accessor function performs the following steps:

--- a/JS.md
+++ b/JS.md
@@ -518,12 +518,11 @@ call one with the `new` operator.
 
 A `WebAssembly.Memory` object contains a single [linear memory](Semantics.md#linear-memory)
 which can be simultaneously referenced by multiple `Instance` objects. Each
-`Memory` object has four internal slots:
+`Memory` object has three internal slots:
 
  * [[Memory]] : a [`Memory.memory`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/memory.mli)
  * [[BufferObject]] : the current `ArrayBuffer` whose [[ArrayBufferByteLength]]
    matches the current byte length of [[Memory]]
- * [[Initial]] : the `initial` number of WebAssembly pages
  * [[Maximum]] : the `maximum` number of WebAssembly pages, or `undefined` if `maximum` is `None`
 
 ### `WebAssembly.Memory` Constructor
@@ -571,8 +570,7 @@ the detachment performed by [`m.grow`](#webassemblymemoryprototypegrow) shall th
 
 Return a new `WebAssembly.Memory` instance with
 [[Memory]] set to `m`,
-[[BufferObject]] set to `buffer`,
-[[Initial]] set to `initial`, and
+[[BufferObject]] set to `buffer`, and
 [[Maximum]] set to `undefined` if `maximum` is `None` or `maximum` otherwise.
 
 ### `WebAssembly.Memory.prototype [ @@toStringTag ]` Property
@@ -621,7 +619,7 @@ accessor function performs the following steps:
 If `this` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown. Otherwise return `M.[[BufferObject]]`.
 
-### `WebAssembly.Memory.prototype.byteLength`
+### `WebAssembly.Memory.prototype.length`
 
 [⚜](#Post-MVP-JavaScript-API)
 
@@ -632,18 +630,6 @@ Let `T` be the `this` value. If `T` is not a `WebAssembly.Memory`, a [`TypeError
 is thrown.
 
 Return `T.[[BufferObject]].[[ArrayBufferByteLength]]`.
-
-### `WebAssembly.Memory.prototype.initial`
-
-[⚜](#Post-MVP-JavaScript-API)
-
-This is an accessor property whose [[Set]] is Undefined and whose [[Get]]
-accessor function performs the following steps:
-
-Let `T` be the `this` value. If `T` is not a `WebAssembly.Memory`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
-is thrown.
-
-Return `T.[[Initial]]`.
 
 ### `WebAssembly.Memory.prototype.maximum`
 


### PR DESCRIPTION
As suggested in #1024.

I'll follow-up with a similar suggestion for WebAssembly.Instance, which needs its own discussion about encapsulation as well as multiple memories. WebAssembly.Memory is simpler: there's only one Memory and it's not encapsulated.