### PR TITLE
Add links for definitions far away

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -234,7 +234,7 @@ The type section declares all function signatures that will be used in the modul
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | count | `varuint32` | count of type entries to follow |
-| entries | `func_type*` | repeated type entries as described below |
+| entries | `func_type*` | repeated type entries as described [above](#func_type) |
 
 Note: In the [future :unicorn:][future types],
 this section may contain other forms of type entries as well, which can be distinguished by the `form` field of the type encoding.
@@ -301,7 +301,7 @@ The encoding of a [Table section](Modules.md#table-section):
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | count | `varuint32` | indicating the number of tables defined by the module |
-| entries | `table_type*` | repeated `table_type` entries as described below |
+| entries | `table_type*` | repeated `table_type` entries as described [above](#table_type) |
 
 In the MVP, the number of tables must be no more than 1.
 
@@ -314,7 +314,7 @@ The encoding of a [Memory section](Modules.md#linear-memory-section):
 | Field | Type | Description |
 | ----- |  ----- | ----- |
 | count | `varuint32` | indicating the number of memories defined by the module |
-| entries | `memory_type*` | repeated `memory_type` entries as described below |
+| entries | `memory_type*` | repeated `memory_type` entries as described [above](#memory_type) |
 
 Note that the initial/maximum fields are specified in units of 
 [WebAssembly pages](Semantics.md#linear-memory).


### PR DESCRIPTION
Also, replace "below" by "above" if appropriate.