### PR TITLE
Throw `TypeError` on incorrect MIME type

### DIFF
--- a/Web.md
+++ b/Web.md
@@ -69,7 +69,7 @@ from the `Response`, WebAssembly `source` data must have a MIME type of `applica
 extra parameters are not allowed (including empty `application/wasm;`).
 MIME type mismatch or `opaque` response types
 [reject](http://tc39.github.io/ecma262/#sec-rejectpromise) the Promise with a
-`WebAssembly.CompileError`.
+`TypeError`.
 
 #### `WebAssembly.instantiate`
 


### PR DESCRIPTION
Proposing that we throw `TypeError` when the Response parameter has incorrect MIME type. This seems more in-line to what we do for:

`WebAssembly.{compile|instantiate}("hello!")`