### PR TITLE
Expand binary name section to include type, table, memory, global, and label names.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -457,6 +457,11 @@ be skipped over by an engine. The current list of valid `name_type` codes are:
 | [Module](#module-name)      | `0`  | Assigns a name to the module         |
 | [Function](#function-names) | `1`  | Assigns names to functions           |
 | [Local](#local-names)       | `2`  | Assigns names to locals in functions |
+| [Labels](#label-names)      | `3`  | Assigns names to labels in functions |
+| [Type](#type-names)         | `4`  | Assigns names to types               |
+| [Table](#table-names)       | `5`  | Assigns names to tables              |
+| [Memory](#memory-names)     | `6`  | Assigns names to memories            |
+| [Global](#global-names)     | `7`  | Assigns names to globals             |
 
 
 When present, subsections must appear in this order and at most once. The
@@ -521,6 +526,58 @@ where a `local_name` is encoded as:
 | ----- | ---- | ----------- |
 | index | `varuint32` | the index of the function whose locals are being named |
 | local_map | `name_map` | assignment of names to local indices |
+
+#### Label names
+
+The label names subsection assigns `name_map`s to a subset of functions in the
+[function index space](Modules.md#function-index-space). This may include both
+module-defined or imported functions, but is only meaningful for module-defined
+functions. The `name_map` for a function assigns names to label indices, with
+label indices assigned sequentially to the labels in the order they are introduced
+by control structure operators (i.e. `block`, `loop`, or `if`) in the function's
+code.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| count | `varuint32` | count of `label_names` in funcs |
+| funcs | `label_names*` | sequence of `label_names` sorted by index |
+
+where a `label_name` is encoded as:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| index | `varuint32` | the index of the function whose labels are being named |
+| label_map | `name_map` | assignment of names to labeling operator |
+
+#### Type names
+
+The type names subsection is a `name_map` which assigns names to a subset
+of types in the module's [type section](#type-section).
+
+#### Table names
+
+The table names subsection is a `name_map` which assigns names to a subset
+of tables in the [table index space](Modules.md#table-index-space).
+
+#### Memory names
+
+The memory names subsection is a `name_map` which assigns names to a subset
+of memories in the [linear memory index space](Modules.md#linear-memory-index-space).
+
+#### Global names
+
+The global names subsection is a `name_map` which assigns names to a subset
+of globals in the [global index space](Modules.md#global-index-space).
+
+#### Module name
+
+The module name subsection assigns a name to the module itself. It simply
+consists of a single string:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| name_len | `varuint32` | length of `name_str` in bytes |
+| name_str | `bytes` | UTF-8 encoding of the name |
 
 # Function Bodies
 


### PR DESCRIPTION
This is meant to resolve #750.