### PR TITLE
Define non-trapping float-to-int conversions.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -810,14 +810,14 @@ for [future :unicorn:][future multiple tables] use and must be 0 in the MVP.
 | `f64.convert_s/i64` | `0xb9` | | |
 | `f64.convert_u/i64` | `0xba` | | |
 | `f64.promote/f32` | `0xbb` | | |
-| `i32.trunc_s:sat/f32` | `0xfc` `0x00` | | saturating form of `i32.trunc_s/f32` |
-| `i32.trunc_u:sat/f32` | `0xfc` `0x01` | | saturating form of `i32.trunc_u/f32` |
-| `i32.trunc_s:sat/f64` | `0xfc` `0x02` | | saturating form of `i32.trunc_s/f64` |
-| `i32.trunc_u:sat/f64` | `0xfc` `0x03` | | saturating form of `i32.trunc_u/f64` |
-| `i64.trunc_s:sat/f32` | `0xfc` `0x04` | | saturating form of `i64.trunc_s/f32` |
-| `i64.trunc_u:sat/f32` | `0xfc` `0x05` | | saturating form of `i64.trunc_u/f32` |
-| `i64.trunc_s:sat/f64` | `0xfc` `0x06` | | saturating form of `i64.trunc_s/f64` |
-| `i64.trunc_u:sat/f64` | `0xfc` `0x07` | | saturating form of `i64.trunc_u/f64` |
+| `i32.trunc_s:sat/f32` | `0xfc` `0x00` | | :bowling: saturating form of `i32.trunc_s/f32` |
+| `i32.trunc_u:sat/f32` | `0xfc` `0x01` | | :bowling: saturating form of `i32.trunc_u/f32` |
+| `i32.trunc_s:sat/f64` | `0xfc` `0x02` | | :bowling: saturating form of `i32.trunc_s/f64` |
+| `i32.trunc_u:sat/f64` | `0xfc` `0x03` | | :bowling: saturating form of `i32.trunc_u/f64` |
+| `i64.trunc_s:sat/f32` | `0xfc` `0x04` | | :bowling: saturating form of `i64.trunc_s/f32` |
+| `i64.trunc_u:sat/f32` | `0xfc` `0x05` | | :bowling: saturating form of `i64.trunc_u/f32` |
+| `i64.trunc_s:sat/f64` | `0xfc` `0x06` | | :bowling: saturating form of `i64.trunc_s/f64` |
+| `i64.trunc_u:sat/f64` | `0xfc` `0x07` | | :bowling: saturating form of `i64.trunc_u/f64` |
 
 ## Reinterpretations ([described here](Semantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions))
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -57,12 +57,20 @@ Note: Currently, the only sizes used are `varint7`, `varint32` and `varint64`.
 
 ## Instruction Opcodes
 
-In the MVP, the opcodes of [instructions](Semantics.md) are all encoded in a
-single byte since there are fewer than 256 opcodes. Future features like
-[SIMD][future simd] and [atomics][future threads]
-will bring the total count above 256 and so an extension scheme will be
-necessary, designating one or more single-byte values as prefixes for multi-byte
-opcodes.
+The opcodes for many common instructions are encoded in a single byte.
+
+The opcodes for some families of instructions are encoded as a *prefix byte*
+followed by an LEB128 value. Prefix byte values are allocated starting at `0xfe`
+and counting downwards.
+
+### Prefix Bytes
+
+| Opcode | Name     | Description |
+| ------ | -------- | ----------- |
+| `0xff` | reserved | Reserved for unknown future language evolution |
+| `0xfe` | threads  | Expected to be used for [atomics][future threads] |
+| `0xfd` | simd     | Expected to be used for [SIMD][future simd] |
+| `0xfc` | numeric  | Numeric operations |
 
 ## Language Types
 
@@ -802,6 +810,14 @@ for [future :unicorn:][future multiple tables] use and must be 0 in the MVP.
 | `f64.convert_s/i64` | `0xb9` | | |
 | `f64.convert_u/i64` | `0xba` | | |
 | `f64.promote/f32` | `0xbb` | | |
+| `i32.trunc_s:sat/f32` | `0xfc` `0x00` | | saturating form of `i32.trunc_s/f32` |
+| `i32.trunc_u:sat/f32` | `0xfc` `0x01` | | saturating form of `i32.trunc_u/f32` |
+| `i32.trunc_s:sat/f64` | `0xfc` `0x02` | | saturating form of `i32.trunc_s/f64` |
+| `i32.trunc_u:sat/f64` | `0xfc` `0x03` | | saturating form of `i32.trunc_u/f64` |
+| `i64.trunc_s:sat/f32` | `0xfc` `0x04` | | saturating form of `i64.trunc_s/f32` |
+| `i64.trunc_u:sat/f32` | `0xfc` `0x05` | | saturating form of `i64.trunc_u/f32` |
+| `i64.trunc_s:sat/f64` | `0xfc` `0x06` | | saturating form of `i64.trunc_s/f64` |
+| `i64.trunc_u:sat/f64` | `0xfc` `0x07` | | saturating form of `i64.trunc_u/f64` |
 
 ## Reinterpretations ([described here](Semantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions))
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -67,10 +67,10 @@ and counting downwards.
 
 | Opcode | Name     | Description |
 | ------ | -------- | ----------- |
-| `0xff` | reserved | Reserved for unknown future language evolution |
-| `0xfe` | threads  | Expected to be used for [atomics][future threads] |
-| `0xfd` | simd     | Expected to be used for [SIMD][future simd] |
-| `0xfc` | numeric  | Numeric operations |
+| `0xff` | reserved | Reserved for unknown future language evolution :milky_way: |
+| `0xfe` | threads  | Expected to be used for [atomics :unicorn:][future threads] |
+| `0xfd` | simd     | Expected to be used for [SIMD :unicorn:][future simd] |
+| `0xfc` | numeric  | Numeric operations :bowling: |
 
 ## Language Types
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -70,7 +70,7 @@ and counting downwards.
 | `0xff` | reserved | Reserved for unknown future language evolution :milky_way: |
 | `0xfe` | threads  | Expected to be used for [atomics :unicorn:][future threads] |
 | `0xfd` | simd     | Expected to be used for [SIMD :unicorn:][future simd] |
-| `0xfc` | numeric  | Numeric operations :bowling: |
+| `0xfc` | misc     | Miscellaneous operations :bowling: |
 
 ## Language Types
 

--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -810,14 +810,14 @@ for [future :unicorn:][future multiple tables] use and must be 0 in the MVP.
 | `f64.convert_s/i64` | `0xb9` | | |
 | `f64.convert_u/i64` | `0xba` | | |
 | `f64.promote/f32` | `0xbb` | | |
-| `i32.trunc_s:sat/f32` | `0xfc` `0x00` | | :bowling: saturating form of `i32.trunc_s/f32` |
-| `i32.trunc_u:sat/f32` | `0xfc` `0x01` | | :bowling: saturating form of `i32.trunc_u/f32` |
-| `i32.trunc_s:sat/f64` | `0xfc` `0x02` | | :bowling: saturating form of `i32.trunc_s/f64` |
-| `i32.trunc_u:sat/f64` | `0xfc` `0x03` | | :bowling: saturating form of `i32.trunc_u/f64` |
-| `i64.trunc_s:sat/f32` | `0xfc` `0x04` | | :bowling: saturating form of `i64.trunc_s/f32` |
-| `i64.trunc_u:sat/f32` | `0xfc` `0x05` | | :bowling: saturating form of `i64.trunc_u/f32` |
-| `i64.trunc_s:sat/f64` | `0xfc` `0x06` | | :bowling: saturating form of `i64.trunc_s/f64` |
-| `i64.trunc_u:sat/f64` | `0xfc` `0x07` | | :bowling: saturating form of `i64.trunc_u/f64` |
+| `i32.trunc_sat_f32_s` | `0xfc` `0x00` | | :bowling: saturating form of `i32.trunc_f32_s` |
+| `i32.trunc_sat_f32_u` | `0xfc` `0x01` | | :bowling: saturating form of `i32.trunc_f32_u` |
+| `i32.trunc_sat_f64_s` | `0xfc` `0x02` | | :bowling: saturating form of `i32.trunc_f64_s` |
+| `i32.trunc_sat_f64_u` | `0xfc` `0x03` | | :bowling: saturating form of `i32.trunc_f64_u` |
+| `i64.trunc_sat_f32_s` | `0xfc` `0x04` | | :bowling: saturating form of `i64.trunc_f32_s` |
+| `i64.trunc_sat_f32_u` | `0xfc` `0x05` | | :bowling: saturating form of `i64.trunc_f32_u` |
+| `i64.trunc_sat_f64_s` | `0xfc` `0x06` | | :bowling: saturating form of `i64.trunc_f64_s` |
+| `i64.trunc_sat_f64_u` | `0xfc` `0x07` | | :bowling: saturating form of `i64.trunc_f64_u` |
 
 ## Reinterpretations ([described here](Semantics.md#datatype-conversions-truncations-reinterpretations-promotions-and-demotions))
 

--- a/Semantics.md
+++ b/Semantics.md
@@ -648,14 +648,14 @@ is NaN, and *ordered* otherwise.
   * `f64.convert_u/i32`: convert an unsigned 32-bit integer to a 64-bit float
   * `f64.convert_u/i64`: convert an unsigned 64-bit integer to a 64-bit float
   * `f64.reinterpret/i64`: reinterpret the bits of a 64-bit integer as a 64-bit float
-  * `i32.trunc_s:sat/f32`: :bowling: truncate a 32-bit float to a signed 32-bit integer with saturation
-  * `i32.trunc_s:sat/f64`: :bowling: truncate a 64-bit float to a signed 32-bit integer with saturation
-  * `i32.trunc_u:sat/f32`: :bowling: truncate a 32-bit float to an unsigned 32-bit integer with saturation
-  * `i32.trunc_u:sat/f64`: :bowling: truncate a 64-bit float to an unsigned 32-bit integer with saturation
-  * `i64.trunc_s:sat/f32`: :bowling: truncate a 32-bit float to a signed 64-bit integer with saturation
-  * `i64.trunc_s:sat/f64`: :bowling: truncate a 64-bit float to a signed 64-bit integer with saturation
-  * `i64.trunc_u:sat/f32`: :bowling: truncate a 32-bit float to an unsigned 64-bit integer with saturation
-  * `i64.trunc_u:sat/f64`: :bowling: truncate a 64-bit float to an unsigned 64-bit integer with saturation
+  * `i32.trunc_sat_f32_s`: :bowling: truncate a 32-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_sat_f64_s`: :bowling: truncate a 64-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_sat_f32_u`: :bowling: truncate a 32-bit float to an unsigned 32-bit integer with saturation
+  * `i32.trunc_sat_f64_u`: :bowling: truncate a 64-bit float to an unsigned 32-bit integer with saturation
+  * `i64.trunc_sat_f32_s`: :bowling: truncate a 32-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_sat_f64_s`: :bowling: truncate a 64-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_sat_f32_u`: :bowling: truncate a 32-bit float to an unsigned 64-bit integer with saturation
+  * `i64.trunc_sat_f64_u`: :bowling: truncate a 64-bit float to an unsigned 64-bit integer with saturation
 
 Wrapping and extension of integer values always succeed.
 Promotion and demotion of floating point values always succeed.
@@ -683,7 +683,7 @@ Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operator exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) is handled as follows:
  - For instructions with no exceptional behavior specified, a trap is produced.
- - :bowling: For instructions with the `:sat` modifier, no trap is produced, and:
+ - :bowling: For instructions containing `_sat`, no trap is produced, and:
     - If the floating-point value is positive, the maximum integer value is returned.
     - If the floating-point value is negative, the minimum integer value is returned.
     - If the floating-point value is NaN, zero is returned.

--- a/Semantics.md
+++ b/Semantics.md
@@ -640,6 +640,14 @@ is NaN, and *ordered* otherwise.
   * `f64.convert_u/i32`: convert an unsigned 32-bit integer to a 64-bit float
   * `f64.convert_u/i64`: convert an unsigned 64-bit integer to a 64-bit float
   * `f64.reinterpret/i64`: reinterpret the bits of a 64-bit integer as a 64-bit float
+  * `i32.trunc_s:sat/f32`: truncate a 32-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_s:sat/f64`: truncate a 64-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_u:sat/f32`: truncate a 32-bit float to an unsigned 32-bit integer with saturation
+  * `i32.trunc_u:sat/f64`: truncate a 64-bit float to an unsigned 32-bit integer with saturation
+  * `i64.trunc_s:sat/f32`: truncate a 32-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_s:sat/f64`: truncate a 64-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_u:sat/f32`: truncate a 32-bit float to an unsigned 64-bit integer with saturation
+  * `i64.trunc_u:sat/f64`: truncate a 64-bit float to an unsigned 64-bit integer with saturation
 
 Wrapping and extension of integer values always succeed.
 Promotion and demotion of floating point values always succeed.
@@ -665,7 +673,12 @@ round-to-nearest ties-to-even rounding.
 
 Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operator exception (e.g. when the floating point value is NaN or
-outside the range which rounds to an integer in range) traps.
+outside the range which rounds to an integer in range) is handled as follows:
+ - For instructions with no exceptional behavior specified, a trap is produced.
+ - For instructions with the `:sat` modifier, no trap is produced, and:
+    - If the floating-point value is positive, the maximum integer value is returned.
+    - If the floating-point value is negative, the minimum integer value is returned.
+    - If the floating-point value is NaN, zero is returned.
 
 ## Type-parametric operators
 

--- a/Semantics.md
+++ b/Semantics.md
@@ -35,6 +35,14 @@ detailed in this document.
 
 [:unicorn:][future general] = Planned [future][future general] feature
 
+## Post-MVP Features
+
+Some features were added post-MVP. These are indicated with the following symbols:
+
+| Symbol     | Feature |
+| ---------- | ------- |
+| :bowling:  | Saturating float to int conversions |
+
 ## Traps
 
 Some operators may *trap* under some conditions, as noted below. In the MVP,
@@ -640,14 +648,14 @@ is NaN, and *ordered* otherwise.
   * `f64.convert_u/i32`: convert an unsigned 32-bit integer to a 64-bit float
   * `f64.convert_u/i64`: convert an unsigned 64-bit integer to a 64-bit float
   * `f64.reinterpret/i64`: reinterpret the bits of a 64-bit integer as a 64-bit float
-  * `i32.trunc_s:sat/f32`: truncate a 32-bit float to a signed 32-bit integer with saturation
-  * `i32.trunc_s:sat/f64`: truncate a 64-bit float to a signed 32-bit integer with saturation
-  * `i32.trunc_u:sat/f32`: truncate a 32-bit float to an unsigned 32-bit integer with saturation
-  * `i32.trunc_u:sat/f64`: truncate a 64-bit float to an unsigned 32-bit integer with saturation
-  * `i64.trunc_s:sat/f32`: truncate a 32-bit float to a signed 64-bit integer with saturation
-  * `i64.trunc_s:sat/f64`: truncate a 64-bit float to a signed 64-bit integer with saturation
-  * `i64.trunc_u:sat/f32`: truncate a 32-bit float to an unsigned 64-bit integer with saturation
-  * `i64.trunc_u:sat/f64`: truncate a 64-bit float to an unsigned 64-bit integer with saturation
+  * `i32.trunc_s:sat/f32`: :bowling: truncate a 32-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_s:sat/f64`: :bowling: truncate a 64-bit float to a signed 32-bit integer with saturation
+  * `i32.trunc_u:sat/f32`: :bowling: truncate a 32-bit float to an unsigned 32-bit integer with saturation
+  * `i32.trunc_u:sat/f64`: :bowling: truncate a 64-bit float to an unsigned 32-bit integer with saturation
+  * `i64.trunc_s:sat/f32`: :bowling: truncate a 32-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_s:sat/f64`: :bowling: truncate a 64-bit float to a signed 64-bit integer with saturation
+  * `i64.trunc_u:sat/f32`: :bowling: truncate a 32-bit float to an unsigned 64-bit integer with saturation
+  * `i64.trunc_u:sat/f64`: :bowling: truncate a 64-bit float to an unsigned 64-bit integer with saturation
 
 Wrapping and extension of integer values always succeed.
 Promotion and demotion of floating point values always succeed.
@@ -675,7 +683,7 @@ Truncation from floating point to integer where IEEE 754-2008 would specify an
 invalid operator exception (e.g. when the floating point value is NaN or
 outside the range which rounds to an integer in range) is handled as follows:
  - For instructions with no exceptional behavior specified, a trap is produced.
- - For instructions with the `:sat` modifier, no trap is produced, and:
+ - :bowling: For instructions with the `:sat` modifier, no trap is produced, and:
     - If the floating-point value is positive, the maximum integer value is returned.
     - If the floating-point value is negative, the minimum integer value is returned.
     - If the floating-point value is NaN, zero is returned.


### PR DESCRIPTION
This also introduces the concept of prefix bytes, and defines the "numeric" prefix byte, used for encoding the new conversion instructions.

As far as I'm aware, this proposal is fully in accord with the [CG guidance](https://github.com/WebAssembly/meetings/blob/master/2017/CG-05.md#non-trapping-float-to-int) expressed at the recent CG meeting.