### PR TITLE
Fix broken link on ES6 module integration

### DIFF
--- a/Modules.md
+++ b/Modules.md
@@ -6,7 +6,7 @@ with a set of import values to produce an **instance**, which is an immutable
 tuple referencing all the state accessible to the running module. Multiple
 module instances can access the same shared state which is the basis for 
 [dynamic linking](DynamicLinking.md) in WebAssembly. WebAssembly modules
-are also designed to [integrate with ES6 modules](#integration-with-es6-modules).
+are also meant to integrate with ES6 modules in the [future :unicorn:][future ES6 modules].
 
 A module contains the following sections:
 
@@ -327,6 +327,7 @@ to the following nullary operators:
 In the future, operators like `i32.add` could be added to allow more expressive
 `base + offset` load-time calculations.
 
+[future ES6 modules]: FutureFeatures.md#tracking-issues
 [future types]: FutureFeatures.md#more-table-operators-and-types
 [future dom]: FutureFeatures.md#gc/dom-integration
 [future multiple tables]: FutureFeatures.md#multiple-tables-and-memories


### PR DESCRIPTION
Redirected a link on ES6 module integration to the future features page.