### PR TITLE
Remove dead link to GC.md

### DIFF
--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -125,7 +125,7 @@ Options under consideration:
 
 ### GC/DOM Integration
 
-See [GC.md](GC.md).
+See issue [1079][].
 
 ### Linear memory bigger than 4 GiB
 


### PR DESCRIPTION
This file was removed in commit ebf42442957395ed98b314b90924df82854c44b8, from pull request #1080.

The contribution guidelines request joining the W3C Community Group before submitting PRs. I'm attempting to do that now but their site appears to be busted.