### PR TITLE
Rewrite URLs that support HTTPS (http:// -> https://)

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -52,7 +52,7 @@ greater performance will be added soon after, including:
    and [GCC's vector extensions], auto-vectorization, and emulated APIs from
    other platforms such as `<xmmintrin.h>`.
 
-  [LLVM's vector extensions]: http://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors
+  [LLVM's vector extensions]: https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors
   [GCC's vector extensions]: https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
 
 ### APIs

--- a/Events.md
+++ b/Events.md
@@ -2,7 +2,7 @@
 
 | Date | Title | Slides | Video | Presenter(s) |
 |-----:|-------|:------:|:-----:|--------------|
-| October   29th 2015 | LLVM Developers' Meeting   | [slides](http://llvm.org/devmtg/2015-10/slides/BastienGohman-WebAssembly-HereBeDragons.pdf) | [video](https://www.youtube.com/watch?v=5W7NkofUtAw) | JF Bastien and Dan Gohman |
+| October   29th 2015 | LLVM Developers' Meeting   | [slides](https://llvm.org/devmtg/2015-10/slides/BastienGohman-WebAssembly-HereBeDragons.pdf) | [video](https://www.youtube.com/watch?v=5W7NkofUtAw) | JF Bastien and Dan Gohman |
 | November  10th 2015 | BlinkOn 5: WebAssembly     | | [video](https://youtu.be/iCSAUHpPbiU) | Nick Bray |
 | December   9th 2015 | Emscripten and WebAssembly | [slides](https://kripken.github.io/talks/wasm.html) | | Alon Zakai |
 | January   31st 2016 | FOSDEM LLVM room           | [slides](https://fosdem.org/2016/schedule/event/llvm_webassembly) | | JF Bastien and Dan Gohman |

--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ allocate and access garbage-collected (JavaScript, DOM, Web API) objects
 :unicorn:][future garbage collection].
 Even before GC support is added to WebAssembly, it is possible to compile a language's VM 
 to WebAssembly (assuming it's written in portable C/C++) and this has already been demonstrated 
-([1](http://ruby.dj), [2](https://kripken.github.io/lua.vm.js/lua.vm.js.html),
+([1](https://ruby.dj), [2](https://kripken.github.io/lua.vm.js/lua.vm.js.html),
 [3](https://syntensity.blogspot.com/2010/12/python-demo.html)).  However, "compile the VM" strategies 
 increase the size of distributed code, lose browser devtools integration, can have cross-language
 cycle-collection problems and miss optimizations that require integration with the browser.
@@ -185,7 +185,7 @@ together in a number of configurations:
 
 ## Why not just use LLVM bitcode as a binary format?
 
-The [LLVM](http://llvm.org/) compiler infrastructure has a lot to recommend it:
+The [LLVM](https://llvm.org/) compiler infrastructure has a lot to recommend it:
 it has an existing intermediate representation (LLVM IR) and binary encoding
 format (bitcode). It has code generation backends targeting many architectures
 is actively developed and maintained by a large community. In fact
@@ -305,7 +305,7 @@ it, but fast-math flags are not believed to be important enough:
 
 ## What about `mmap`?
 
-The [`mmap`](http://pubs.opengroup.org/onlinepubs/009695399/functions/mmap.html)
+The [`mmap`](https://pubs.opengroup.org/onlinepubs/009695399/functions/mmap.html)
 syscall has many useful features. While these are all packed into one overloaded
 syscall in POSIX, WebAssembly unpacks this functionality into multiple
 operators:
@@ -379,7 +379,7 @@ those that motivated the development of the
 [x32 ABI](https://en.wikipedia.org/wiki/X32_ABI) for Linux.
 
 Even Knuth found it worthwhile to give us his opinion on this issue at point,
-[a flame about 64-bit pointers](http://www-cs-faculty.stanford.edu/~uno/news08.html).
+[a flame about 64-bit pointers](https://www-cs-faculty.stanford.edu/~uno/news08.html).
 
 ## Will I be able to access proprietary platform APIs (e.g. Android / iOS)?
 

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -177,7 +177,7 @@ supporting both in the same instance in the future.
 Coroutines will [eventually be part of C++][] and is already popular in other
 programming languages that WebAssembly will support.
 
-  [eventually be part of C++]: http://wg21.link/n4499
+  [eventually be part of C++]: https://wg21.link/n4499
 
 ### Asynchronous Signals
 
@@ -385,7 +385,7 @@ When the application is prepared to handle overflow locally, it would be useful
 to have arithmetic operators which can indicate when overflow occurred. An
 example of this is the checked arithmetic builtins available in compilers such
 as
-[clang](http://clang.llvm.org/docs/LanguageExtensions.html#checked-arithmetic-builtins)
+[clang](https://clang.llvm.org/docs/LanguageExtensions.html#checked-arithmetic-builtins)
 and
 [GCC](https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html).
 If WebAssembly is made to support nodes with multiple return values, that could

--- a/JS.md
+++ b/JS.md
@@ -58,11 +58,11 @@ The following intrinsic objects are added:
 * `WebAssembly.Instance` : the [`WebAssembly.Instance` constructor](#webassemblyinstance-constructor)
 * `WebAssembly.Memory` : the [`WebAssembly.Memory` constructor](#webassemblymemory-constructor)
 * `WebAssembly.Table` : the [`WebAssembly.Table` constructor](#webassemblytable-constructor)
-* `WebAssembly.CompileError` : a [NativeError](http://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
+* `WebAssembly.CompileError` : a [NativeError](https://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
    which indicates an error during WebAssembly decoding or validation
-* `WebAssembly.LinkError` : a [NativeError](http://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
+* `WebAssembly.LinkError` : a [NativeError](https://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
    which indicates an error during WebAssembly instantiating a module (other than traps from the start function)
-* `WebAssembly.RuntimeError` : a [NativeError](http://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
+* `WebAssembly.RuntimeError` : a [NativeError](https://tc39.github.io/ecma262/#sec-nativeerror-object-structure)
    which is thrown whenever WebAssembly specifies a [trap](#traps).
 
 ### Function Properties of the `WebAssembly` object
@@ -92,14 +92,14 @@ Promise<WebAssembly.Module> compile(BufferSource bytes)
 
 If the given `bytes` argument is not a
 [`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
-the returned `Promise` is [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
+the returned `Promise` is [rejected](https://tc39.github.io/ecma262/#sec-rejectpromise)
 with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 Otherwise, this function starts an asynchronous task to compile a `WebAssembly.Module`
 as described in the [`WebAssembly.Module` constructor](#webassemblymodule-constructor).
-On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
+On success, the `Promise` is [fulfilled](https://tc39.github.io/ecma262/#sec-fulfillpromise)
 with the resulting `WebAssembly.Module` object. On failure, the `Promise` is 
-[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
+[rejected](https://tc39.github.io/ecma262/#sec-rejectpromise) with a 
 `WebAssembly.CompileError`.
 
 The asynchronous compilation is logically performed on a copy of the state of
@@ -110,7 +110,7 @@ of the `BufferSource` after `compile` return do not affect ongoing compilations.
 
 The `instantiate` function is overloaded based on types of its arguments.
 If neither of the following overloads match, then the returned `Promise` is
-[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
+[rejected](https://tc39.github.io/ecma262/#sec-rejectpromise)
 with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 ```
@@ -125,7 +125,7 @@ Promise<WebAssemblyInstantiatedSource>
 
 If the given `bytes` argument is not a
 [`BufferSource`](https://heycam.github.io/webidl/#common-BufferSource),
-the returned `Promise` is [rejected](http://tc39.github.io/ecma262/#sec-rejectpromise)
+the returned `Promise` is [rejected](https://tc39.github.io/ecma262/#sec-rejectpromise)
 with a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 This function starts an asynchronous task that first compiles a `WebAssembly.Module`
@@ -133,12 +133,12 @@ from `bytes` as described in the [`WebAssembly.Module` constructor](#webassembly
 and then queue a task to instantiate the resulting `Module` with `importObject` as described in the
 [`WebAssembly.Instance` constructor](#webassemblyinstance-constructor). After the instantiation task runs
 and before any subsequent steps are taken, other unspecified asynchronous tasks may be run.
-On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
+On success, the `Promise` is [fulfilled](https://tc39.github.io/ecma262/#sec-fulfillpromise)
 with a plain JavaScript object pair `{module, instance}` containing the resulting
 `WebAssembly.Module` and `WebAssembly.Instance`. The 2 properties `module` and `instance` of the returned pair are  configurable, enumerable and writable. 
 
 On failure, the `Promise` is
-[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
+[rejected](https://tc39.github.io/ecma262/#sec-rejectpromise) with a 
 `WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
 
 The asynchronous compilation is logically performed on a copy of the state of
@@ -155,9 +155,9 @@ This function asynchronously queues a task that instantiates a `WebAssembly.Inst
 from `moduleObject` and `importObject` as described in the
 [`WebAssembly.Instance` constructor](#webassemblyinstance-constructor). After the instantiation task runs
 and before any subsequent steps are taken, other unspecified asynchronous tasks may be run.
-On success, the `Promise` is [fulfilled](http://tc39.github.io/ecma262/#sec-fulfillpromise)
+On success, the `Promise` is [fulfilled](https://tc39.github.io/ecma262/#sec-fulfillpromise)
 with the resulting `WebAssembly.Instance` object. On failure, the `Promise` is
-[rejected](http://tc39.github.io/ecma262/#sec-rejectpromise) with a 
+[rejected](https://tc39.github.io/ecma262/#sec-rejectpromise) with a 
 `WebAssembly.CompileError`, `WebAssembly.LinkError`, or `WebAssembly.RuntimeError`, depending on the cause of failure.
 
 ## `WebAssembly.Module` Objects
@@ -286,7 +286,7 @@ sharing.
 
 A `WebAssembly.Instance` object represents the instantiation of a 
 `WebAssembly.Module` into a
-[realm](http://tc39.github.io/ecma262/#sec-code-realms) and has one
+[realm](https://tc39.github.io/ecma262/#sec-code-realms) and has one
 internal slot:
 
 * [[Instance]] : an [`Instance.instance`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L17)
@@ -332,9 +332,9 @@ For each [`import`](https://github.com/WebAssembly/spec/blob/master/interpreter/
 `i` in `module.imports`:
 
 1. Let `o` be the resultant value of performing
-   [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`importObject`, [`i.module_name`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L170)).
+   [`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`importObject`, [`i.module_name`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L170)).
 1. If `Type(o)` is not Object, throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
-1. Let `v` be the value of performing [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`o`, [`i.item_name`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L171))
+1. Let `v` be the value of performing [`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`o`, [`i.item_name`](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/ast.ml#L171))
 1. If `i` is a function import:
    1. If [`IsCallable(v)`](https://tc39.github.io/ecma262/#sec-iscallable) is `false`,
       throw a `WebAssembly.LinkError`.
@@ -486,8 +486,8 @@ Return `T.[[Exports]]`.
 
 A function with [function index](Modules.md#function-index-space) `index`
 from an `Instance` `inst` is reflected to JS via a new kind of *Exported
-Function* [Exotic Object](http://tc39.github.io/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots).
-Like [Bound Function](http://tc39.github.io/ecma262/#sec-bound-function-exotic-objects) Exotic Object,
+Function* [Exotic Object](https://tc39.github.io/ecma262/#sec-built-in-exotic-object-internal-methods-and-slots).
+Like [Bound Function](https://tc39.github.io/ecma262/#sec-bound-function-exotic-objects) Exotic Object,
 Exported Functions do not have the normal function internal slots but instead have:
 
  * [[Closure]] : the [closure](https://github.com/WebAssembly/spec/blob/master/interpreter/spec/instance.ml#L7)
@@ -495,10 +495,10 @@ Exported Functions do not have the normal function internal slots but instead ha
 
 as well as the internal slots required of all builtin functions:
 
- * [[Prototype]] : [%FunctionPrototype%](http://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects)
+ * [[Prototype]] : [%FunctionPrototype%](https://tc39.github.io/ecma262/#sec-well-known-intrinsic-objects)
  * [[Extensible]] : `true`
- * [[Realm]] : the [current Realm Record](http://tc39.github.io/ecma262/#current-realm)
- * [[ScriptOrModule]] : [`GetActiveScriptOrModule`](http://tc39.github.io/ecma262/#sec-getactivescriptormodule)
+ * [[Realm]] : the [current Realm Record](https://tc39.github.io/ecma262/#current-realm)
+ * [[ScriptOrModule]] : [`GetActiveScriptOrModule`](https://tc39.github.io/ecma262/#sec-getactivescriptormodule)
 
 Exported Functions also have the following data properties:
 
@@ -551,10 +551,10 @@ exception is thrown (i.e., this constructor cannot be called as a function witho
 If `Type(memoryDescriptor)` is not Object, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
-Let `initial` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`memoryDescriptor`, `"initial"`)).
+Let `initial` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`memoryDescriptor`, `"initial"`)).
 
-If [`HasProperty`](http://tc39.github.io/ecma262/#sec-hasproperty)(`"maximum"`),
-then let `maximum` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`memoryDescriptor`, `"maximum"`)).
+If [`HasProperty`](https://tc39.github.io/ecma262/#sec-hasproperty)(`"maximum"`),
+then let `maximum` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`memoryDescriptor`, `"maximum"`)).
 If `maximum` is smaller than `initial`, then throw a [`RangeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror).
 Otherwise, let `maximum` be `None`.
 
@@ -571,12 +571,12 @@ Given a [`Memory.memory`](https://github.com/WebAssembly/spec/blob/master/interp
 `m`, to create a `WebAssembly.Memory`:
 
 Let `buffer` be a new `ArrayBuffer` whose
-[[[ArrayBufferData]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
+[[[ArrayBufferData]]](https://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
 aliases `m` and whose 
-[[[ArrayBufferByteLength]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
+[[[ArrayBufferByteLength]]](https://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
 is set to the byte length of `m`.
 
-Any attempts to [`detach`](http://tc39.github.io/ecma262/#sec-detacharraybuffer) `buffer` *other* than
+Any attempts to [`detach`](https://tc39.github.io/ecma262/#sec-detacharraybuffer) `buffer` *other* than
 the detachment performed by [`m.grow`](#webassemblymemoryprototypegrow) shall throw a 
 [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 
@@ -611,12 +611,12 @@ with delta `d`. On failure, a
 [`RangeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror)
 is thrown.
 
-Perform [`DetachArrayBuffer`](http://tc39.github.io/ecma262/#sec-detacharraybuffer)(`M.[[BufferObject]]`).
+Perform [`DetachArrayBuffer`](https://tc39.github.io/ecma262/#sec-detacharraybuffer)(`M.[[BufferObject]]`).
 
 Assign to `M.[[BufferObject]]` a new `ArrayBuffer` whose
-[[[ArrayBufferData]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
+[[[ArrayBufferData]]](https://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
 aliases `M.[[Memory]]` and whose 
-[[[ArrayBufferByteLength]]](http://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
+[[[ArrayBufferByteLength]]](https://tc39.github.io/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
 is set to the new byte length of `M.[[Memory]]`.
 
 Return `ret` as a Number value.
@@ -652,16 +652,16 @@ exception is thrown (i.e., this constructor cannot be called as a function witho
 If `Type(tableDescriptor)` is not Object, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 
-Let `element` be the result of calling [`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"element"`).
+Let `element` be the result of calling [`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"element"`).
 If `element` is not the string `"anyfunc"`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 (Note: this check is intended to be relaxed in the
 [future :unicorn:][future types] to allow different element types.)
 
-Let `initial` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"initial"`)).
+Let `initial` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"initial"`)).
 
-If [`HasProperty`](http://tc39.github.io/ecma262/#sec-hasproperty)(`"maximum"`),
-then let `maximum` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](http://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"maximum"`)). Otherwise, let `maximum` be None.
+If [`HasProperty`](https://tc39.github.io/ecma262/#sec-hasproperty)(`"maximum"`),
+then let `maximum` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"maximum"`)). Otherwise, let `maximum` be None.
 
 If `maximum` is not None and is smaller than `initial`, then throw a [`RangeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror).
 
@@ -769,9 +769,9 @@ Assert: the WebAssembly value's type is not `i64`.
 1. given a WebAssembly `i32` is interpreted as a signed integer, converted (losslessly) to an
   IEEE754 double and then returned as a JavaScript Number
 1. given a WebAssembly `f32` (single-precision IEEE754), convert (losslessly) to
-   a IEEE754 double, [possibly canonicalize NaN](http://tc39.github.io/ecma262/#sec-setvalueinbuffer),
+   a IEEE754 double, [possibly canonicalize NaN](https://tc39.github.io/ecma262/#sec-setvalueinbuffer),
    and return as a JavaScript Number
-1. given a WebAssembly `f64`, [possibly canonicalize NaN](http://tc39.github.io/ecma262/#sec-setvalueinbuffer)
+1. given a WebAssembly `f64`, [possibly canonicalize NaN](https://tc39.github.io/ecma262/#sec-setvalueinbuffer)
    and return as a JavaScript Number
 
 If the WebAssembly value is optional, then given `None`, return JavaScript value
@@ -783,10 +783,10 @@ To coerce a JavaScript value to a given WebAssembly [`value type`](https://githu
 
 Assert: the target value type is not `i64`.
 
-1. coerce to `i32` via [`ToInt32(v)`](http://tc39.github.io/ecma262/#sec-toint32)
-1. coerce to `f32` by first applying [`ToNumber(v)`](http://tc39.github.io/ecma262/#sec-tonumber)
+1. coerce to `i32` via [`ToInt32(v)`](https://tc39.github.io/ecma262/#sec-toint32)
+1. coerce to `f32` by first applying [`ToNumber(v)`](https://tc39.github.io/ecma262/#sec-tonumber)
    and then converting the resulting IEEE754 64-bit double to a 32-bit float using `roundTiesToEven`
-1. coerce to `f64` via [`ToNumber(v)`](http://tc39.github.io/ecma262/#sec-tonumber)
+1. coerce to `f64` via [`ToNumber(v)`](https://tc39.github.io/ecma262/#sec-tonumber)
 
 If the value type is optional, then given `None`, the JavaScript value is
 ignored.
@@ -795,7 +795,7 @@ ignored.
 
 To convert a JavaScript value `v` to an unsigned integer in the range [0, `UINT32_MAX`]:
 
-Let `i` be [`ToInteger`](http://tc39.github.io/ecma262/#sec-tointeger)(`v`).
+Let `i` be [`ToInteger`](https://tc39.github.io/ecma262/#sec-tointeger)(`v`).
 
 If `i` is negative or greater than `UINT32_MAX`, 
 [`RangeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror)

--- a/Rationale.md
+++ b/Rationale.md
@@ -187,7 +187,7 @@ Structured control flow provides simple and size-efficient binary encoding and
 compilation. Any control flow--even irreducible--can be transformed into structured
 control flow with the
 [Relooper](https://github.com/kripken/emscripten/raw/master/docs/paper.pdf)
-[algorithm](http://dl.acm.org/citation.cfm?id=2048224&CFID=670868333&CFTOKEN=46181900),
+[algorithm](https://dl.acm.org/citation.cfm?id=2048224&CFID=670868333&CFTOKEN=46181900),
 with guaranteed low code size overhead, and typically minimal throughput
 overhead (except for pathological cases of irreducible control
 flow). Alternative approaches can generate reducible control flow via node

--- a/Security.md
+++ b/Security.md
@@ -169,7 +169,7 @@ in WebAssembly.
 
   [address space layout randomization]: https://en.wikipedia.org/wiki/Address_space_layout_randomization
   [bounded pointers]: https://en.wikipedia.org/wiki/Bounded_pointer
-  [built-in implementation]: http://clang.llvm.org/docs/ControlFlowIntegrity.html
+  [built-in implementation]: https://clang.llvm.org/docs/ControlFlowIntegrity.html
   [control-flow integrity]: https://research.microsoft.com/apps/pubs/default.aspx?id=64250
   [data execution prevention]: https://en.wikipedia.org/wiki/Executable_space_protection
   [forward-edge control-flow integrity]: https://www.usenix.org/node/184460


### PR DESCRIPTION
All the modified URLs were checked to see if they are available over HTTPS by opening a new tab in the browser, entering the URL in the address bar, changing `http://` to `https://` and then verifying if the resource displayed is the same over HTTP and HTTPS for each URL.

[asmjs.org](http://asmjs.org/) and [emscripten.org](http://emscripten.org/) are [custom domains](https://help.github.com/articles/using-a-custom-domain-with-github-pages/) for [GitHub Pages sites](https://pages.github.com/) which [can now become available over HTTPS](https://blog.github.com/2018-05-01-github-pages-custom-domains-https/) but action is required on each domain's owner's part to secure these custom domains before the URLs may be rewritten to change `http://` to `https://`.