### PR TITLE
Fix broken links to GC.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -391,6 +391,6 @@ access to [proprietary platform-specific APIs](Portability.md#api) of e.g.
 Android / iOS. 
 
 [future general]: FutureFeatures.md
-[future garbage collection]: https://github.com/WebAssembly/design/issues/1079
+[future garbage collection]: https://github.com/WebAssembly/proposals/issues/16
 [future floating point]: FutureFeatures.md#additional-floating-point-operators
 [future memory control]: FutureFeatures.md#finer-grained-control-over-memory

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -514,4 +514,4 @@ though there would be some different performance characteristics.
 
 
 [future trapping]: FutureFeatures.md#trapping-or-non-trapping-strategies
-[future garbage collection]: https://github.com/WebAssembly/design/issues/1079
+[future garbage collection]: https://github.com/WebAssembly/proposals/issues/16

--- a/Rationale.md
+++ b/Rationale.md
@@ -609,4 +609,4 @@ Moreover, programming languages that allow control transfer _expressions_ usuall
 [future integer]: FutureFeatures.md#additional-integer-operations
 [future threads]: https://github.com/WebAssembly/design/issues/1073
 [future simd]: https://github.com/WebAssembly/design/issues/1075
-[future garbage collection]: https://github.com/WebAssembly/design/issues/1079
+[future garbage collection]: https://github.com/WebAssembly/proposals/issues/16

--- a/Rationale.md
+++ b/Rationale.md
@@ -63,7 +63,7 @@ WebAssembly only represents [a few types](Semantics.md#Types).
 * More complex object types aren't semantically useful for MVP: WebAssembly
   seeks to provide the primitive building blocks upon which higher-level
   constructs can be built. They may become useful to support other languages,
-  especially when considering [garbage collection](GC.md).
+  especially when considering [garbage collection][future garbage collection].
 
 
 ## Load/Store Addressing
@@ -609,3 +609,4 @@ Moreover, programming languages that allow control transfer _expressions_ usuall
 [future integer]: FutureFeatures.md#additional-integer-operations
 [future threads]: https://github.com/WebAssembly/design/issues/1073
 [future simd]: https://github.com/WebAssembly/design/issues/1075
+[future garbage collection]: https://github.com/WebAssembly/design/issues/1079

--- a/Semantics.md
+++ b/Semantics.md
@@ -328,7 +328,7 @@ In the MVP, the primary use case of global variables is to represent
 instantiation-time immutable values as a useful building block for
 [dynamic linking](DynamicLinking.md).
 
-After the MVP, when [reference types](GC.md) are added to the set of [value types](#types),
+After the MVP, when [reference types][future garbage collection] are added to the set of [value types](#types),
 global variables will be necessary to allow sharing reference types between
 [threads :unicorn:][future threads] since shared linear memory cannot load or store
 references.
@@ -708,3 +708,4 @@ The details of validation are currently defined by the [spec interpreter](https:
 [future types]: FutureFeatures.md#more-table-operators-and-types
 [future large pages]: FutureFeatures.md#large-page-support
 [future ieee 754]: FutureFeatures.md#full-ieee-754-2008-conformance
+[future garbage collection]: https://github.com/WebAssembly/design/issues/1079

--- a/Semantics.md
+++ b/Semantics.md
@@ -328,7 +328,7 @@ In the MVP, the primary use case of global variables is to represent
 instantiation-time immutable values as a useful building block for
 [dynamic linking](DynamicLinking.md).
 
-After the MVP, when [reference types][future garbage collection] are added to the set of [value types](#types),
+After the MVP, when [reference types][future reference types] are added to the set of [value types](#types),
 global variables will be necessary to allow sharing reference types between
 [threads :unicorn:][future threads] since shared linear memory cannot load or store
 references.
@@ -708,4 +708,4 @@ The details of validation are currently defined by the [spec interpreter](https:
 [future types]: FutureFeatures.md#more-table-operators-and-types
 [future large pages]: FutureFeatures.md#large-page-support
 [future ieee 754]: FutureFeatures.md#full-ieee-754-2008-conformance
-[future garbage collection]: https://github.com/WebAssembly/design/issues/1079
+[future reference types]: https://github.com/WebAssembly/proposals/issues/10

--- a/Web.md
+++ b/Web.md
@@ -325,4 +325,4 @@ and access JavaScript, DOM, and general WebIDL-defined objects.
   [SIMD.js-in-asm.js]: http://discourse.specifiction.org/t/request-for-comments-simd-js-in-asm-js
 
 [future simd]: https://github.com/WebAssembly/design/issues/1075
-[future garbage collection]: https://github.com/WebAssembly/design/issues/1079
+[future garbage collection]: https://github.com/WebAssembly/proposals/issues/16


### PR DESCRIPTION
Since GC.md doesn't exist, I link these to the [GitHub issue](https://github.com/WebAssembly/design/issues/1079)