### PR TITLE
Fix broken GitHub emoji.

### DIFF
--- a/BinaryEncoding.md
+++ b/BinaryEncoding.md
@@ -8,19 +8,19 @@ The binary encoding is a dense representation of module information that enables
 small files, fast decoding, and reduced memory usage.
 See the [rationale document](Rationale.md#why-a-binary-encoding) for more detail.
 
-[:unicorn:][future general] = Planned [future][future general] feature
+[🦄][future general] = Planned [future][future general] feature
 
 The encoding is split into three layers:
 
 * **Layer 0** is a simple binary encoding of the bytecode instructions and related data structures.
   The encoding is dense and trivial to interact with, making it suitable for
   scenarios like JIT, instrumentation tools, and debugging.
-* **Layer 1** [:unicorn:][future compression] provides structural compression on top of layer 0, exploiting
+* **Layer 1** [🦄][future compression] provides structural compression on top of layer 0, exploiting
   specific knowledge about the nature of the syntax tree and its nodes.
   The structural compression introduces more efficient encoding of values,
   rearranges values within the module, and prunes structurally identical
   tree nodes.
-* **Layer 2** [:unicorn:][future compression] Layer 2 applies generic compression algorithms, like [gzip](http://www.gzip.org/) and [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/), that are already available in browsers and other tooling.
+* **Layer 2** [🦄][future compression] Layer 2 applies generic compression algorithms, like [gzip](http://www.gzip.org/) and [Brotli](https://datatracker.ietf.org/doc/draft-alakuijala-brotli/), that are already available in browsers and other tooling.
 
 Most importantly, the layering approach allows development and standardization to
 occur incrementally. For example, Layer 1 and Layer 2 encoding techniques can be
@@ -29,7 +29,7 @@ compression techniques  stabilize, they can be standardized and moved into nativ
 implementations.
 
 See
-[proposed layer 1 compression :unicorn:][future compression]
+[proposed layer 1 compression 🦄][future compression]
 for a proposal for layer 1 structural compression.
 
 
@@ -80,7 +80,7 @@ All types are distinguished by a negative `varint7` values that is the first byt
 
 Some of these will be followed by additional fields, see below.
 
-Note: Gaps are reserved for [future :unicorn:][future general] extensions. The use of a signed scheme is so that types can coexist in a single space with (positive) indices into the type section, which may be relevant for future extensions of the type system.
+Note: Gaps are reserved for [future 🦄][future general] extensions. The use of a signed scheme is so that types can coexist in a single space with (positive) indices into the type section, which may be relevant for future extensions of the type system.
 
 ### `value_type`
 A `varint7` indicating a [value type](Semantics.md#types). One of:
@@ -105,7 +105,7 @@ In the MVP, only one type is available:
 
 * [`anyfunc`](Semantics.md#table)
 
-Note: In the [future :unicorn:][future general], other element types may be allowed.
+Note: In the [future 🦄][future general], other element types may be allowed.
 
 ### `func_type`
 The description of a function signature. Its type constructor is followed by an additional description:
@@ -118,7 +118,7 @@ The description of a function signature. Its type constructor is followed by an 
 | return_count | `varuint1` | the number of results from the function |
 | return_type | `value_type?` | the result type of the function (if return_count is 1) |
 
-Note: In the [future :unicorn:][future multiple return], `return_count` and `return_type` might be generalised to allow multiple values.
+Note: In the [future 🦄][future multiple return], `return_count` and `return_type` might be generalised to allow multiple values.
 
 ## Other Types
 
@@ -163,7 +163,7 @@ A packed tuple that describes the limits of a
 | initial | `varuint32` | initial length (in units of table elements or wasm pages) |
 | maximum | `varuint32`? | only present if specified by `flags` |
 
-Note: In the [future :unicorn:][future threads], the "flags" field may be changed to `varuint32`, e.g., to include a flag for sharing between threads.
+Note: In the [future 🦄][future threads], the "flags" field may be changed to `varuint32`, e.g., to include a flag for sharing between threads.
 
 ### `init_expr`
 The encoding of an [initializer expression](Modules.md#initializer-expression)
@@ -238,7 +238,7 @@ The type section declares all function signatures that will be used in the modul
 | count | `varuint32` | count of type entries to follow |
 | entries | `func_type*` | repeated type entries as described [above](#func_type) |
 
-Note: In the [future :unicorn:][future types],
+Note: In the [future 🦄][future types],
 this section may contain other forms of type entries as well, which can be distinguished by the `form` field of the type encoding.
 
 ### Import section
@@ -583,7 +583,7 @@ branches to the block or loop at the given offset within the `target_table`. If 
 out of range, `br_table` branches to the default target.
 
 Note: Gaps in the opcode space, here and elsewhere, are reserved for
-[future :unicorn:][future general] extensions.
+[future 🦄][future general] extensions.
 
 ## Call operators ([described here](Semantics.md#calls))
 
@@ -594,7 +594,7 @@ Note: Gaps in the opcode space, here and elsewhere, are reserved for
 
 The `call_indirect` operator takes a list of function arguments and as the last
 operand the index into the table. Its `reserved` immediate is for
-[future :unicorn:][future multiple tables] use and must be `0` in the MVP.
+[future 🦄][future multiple tables] use and must be `0` in the MVP.
 
 ## Parametric operators ([described here](Semantics.md#type-parametric-operators))
 
@@ -654,11 +654,11 @@ As implied by the `log2(alignment)` encoding, the alignment must be a power of 2
 As an additional validation criteria, the alignment must be less or equal to
 natural alignment. The bits after the
 `log(memory-access-size)` least-significant bits must be set to 0. These bits
-are reserved for [future :unicorn:][future threads] use
+are reserved for [future 🦄][future threads] use
 (e.g., for shared memory ordering requirements).
 
 The `reserved` immediate to the `current_memory` and `grow_memory` operators is
-for [future :unicorn:][future multiple tables] use and must be 0 in the MVP.
+for [future 🦄][future multiple tables] use and must be 0 in the MVP.
 
 ## Constants ([described here](Semantics.md#constants))
 

--- a/CAndC++.md
+++ b/CAndC++.md
@@ -20,7 +20,7 @@ has an LP64 data model, meaning that `long` and pointer types will be
 
 [The MVP](MVP.md) will support only wasm32; support for wasm64 will be
 added in the future to support
-[64-bit address spaces :unicorn:][future 64-bit].
+[64-bit address spaces 🦄][future 64-bit].
 
 `float` and `double` are the IEEE 754-2008 single- and double-precision types,
 which are native in WebAssembly. `long double` is the IEEE 754-2008
@@ -131,4 +131,3 @@ implementation.
 [future threads]: https://github.com/WebAssembly/design/issues/1073
 [future simd]: https://github.com/WebAssembly/design/issues/1075
 [future exceptions]: https://github.com/WebAssembly/design/issues/1078
-

--- a/DynamicLinking.md
+++ b/DynamicLinking.md
@@ -69,7 +69,7 @@ To implement run-time dynamic linking (e.g., `dlopen` and `dlsym`):
   search the instances's exports, append the found function to the function
   table (using host-defined functionality in the MVP, but directly from
   WebAssembly code in the
-  [future :unicorn:][future types]) and return the
+  [future 🦄][future types]) and return the
   table index of the appended element to the caller.
 
 Note that the representation of a C function-pointer in WebAssembly is an index

--- a/FAQ.md
+++ b/FAQ.md
@@ -24,7 +24,7 @@ There are two main benefits WebAssembly provides:
 2. By avoiding the simultaneous asm.js constraints of [AOT][]-[compilability][]
    and good performance even on engines without
    [specific asm.js optimizations][], a new standard makes it *much easier* to
-   add the [features :unicorn:][future general] required to reach native
+   add the [features 🦄][future general] required to reach native
    levels of performance.
 
   [experiments]: BinaryEncoding.md#why-a-binary-encoding-instead-of-a-text-only-representation
@@ -96,7 +96,7 @@ reusing a modular C++ library can be as simple as [using a module from JavaScrip
 Beyond the MVP, another [high-level goal](HighLevelGoals.md)
 is to improve support for languages other than C/C++.  This includes [allowing WebAssembly code to
 allocate and access garbage-collected (JavaScript, DOM, Web API) objects
-:unicorn:][future garbage collection].
+🦄][future garbage collection].
 Even before GC support is added to WebAssembly, it is possible to compile a language's VM 
 to WebAssembly (assuming it's written in portable C/C++) and this has already been demonstrated 
 ([1](https://ruby.dj), [2](https://kripken.github.io/lua.vm.js/lua.vm.js.html),
@@ -178,7 +178,7 @@ together in a number of configurations:
   today) allowing developers to reuse popular WebAssembly libraries just like
   JavaScript libraries today.
 * When WebAssembly
-  [gains the ability to access garbage-collected objects :unicorn:][future garbage collection],
+  [gains the ability to access garbage-collected objects 🦄][future garbage collection],
   those objects will be shared with JavaScript, and not live in a walled-off
   world of their own.
 
@@ -284,7 +284,7 @@ it, but fast-math flags are not believed to be important enough:
    would be feature tests allowing WebAssembly code to determine which SIMD
    types to use on a given platform.
  * When WebAssembly
-   [adds an FMA operator :unicorn:][future floating point],
+   [adds an FMA operator 🦄][future floating point],
    folding multiply and add sequences into FMA operators will be possible.
  * WebAssembly doesn't include its own math functions like `sin`, `cos`, `exp`,
    `pow`, and so on. WebAssembly's strategy for such functions is to allow them
@@ -313,7 +313,7 @@ operators:
 * the MVP starts with the ability to grow linear memory via a
   [`grow_memory`](Semantics.md#resizing) operator;
 * proposed
-  [future features :unicorn:][future memory control] would
+  [future features 🦄][future memory control] would
   allow the application to change the protection and mappings for pages in the
   contiguous range `0` to `memory_size`.
 

--- a/FeatureTest.md
+++ b/FeatureTest.md
@@ -2,9 +2,9 @@ See [rationale](Rationale.md#feature-testing---motivating-scenarios) for motivat
 
 # Feature Test
 
-[Post-MVP :unicorn:][future general], applications will be able to query which features are
+[Post-MVP 🦄][future general], applications will be able to query which features are
 supported via
-[`has_feature` or a similar API :unicorn:][future feature testing]. This
+[`has_feature` or a similar API 🦄][future feature testing]. This
 accounts for the pragmatic reality that features are shipped in different orders
 at different times by different engines.
 
@@ -41,15 +41,15 @@ it can be constant-folded by WebAssembly engines.
 
 To illustrate, consider 4 examples:
 
-* [`i32.min_s` :unicorn:][future integer] - Strategy 2
+* [`i32.min_s` 🦄][future integer] - Strategy 2
   could be used to translate `(i32.min_s lhs rhs)` into an equivalent expression
   that stores `lhs` and `rhs` in locals then uses `i32.lt_s` and `select`.
-* [Threads :unicorn:][future threads] - If an application uses `#ifdef` extensively
+* [Threads 🦄][future threads] - If an application uses `#ifdef` extensively
   to produce thread-enabled/disabled builds, Strategy 1 would be appropriate.
   However, if the application was able to abstract use of threading to a few
   primitives, Strategy 2 could be used to patch in the right primitive 
   implementation.
-* [`mprotect` :unicorn:][future memory control] - If engines
+* [`mprotect` 🦄][future memory control] - If engines
   aren't able to use OS signal handling to implement `mprotect` efficiently,
   `mprotect` may become a permanently optional feature. For uses of `mprotect`
   that are not necessary for correctness (but rather just catching bugs),
@@ -97,7 +97,7 @@ polyfill would then replace `foo` with `foo_f64x2` if
 coarser granularity substitution. Since this is all in userspace, the strategy
 can evolve over time.
 
-See also the [better feature testing support :unicorn:][future feature testing]
+See also the [better feature testing support 🦄][future feature testing]
 future feature.
 
 [future general]: FutureFeatures.md

--- a/FutureFeatures.md
+++ b/FutureFeatures.md
@@ -56,17 +56,17 @@ The Community Group and Working Group have adopted [a process document for propo
 
 ## On Deck for Immediate Design
 
-:star: = Essential features we want to prioritize adding shortly after
+⭐ = Essential features we want to prioritize adding shortly after
 the [MVP](MVP.md).
 
 ### Great tooling support
-#### :star: :star: :star:
+#### ⭐ ⭐ ⭐
 
 This is covered in the [tooling](Tooling.md) section.
 
 
 ### Feature Testing
-#### :star:
+#### ⭐
 
 Post-MVP, some form of feature-testing will be required. We don't yet have the
 experience writing polyfills to know whether `has_feature` is the right

--- a/HighLevelGoals.md
+++ b/HighLevelGoals.md
@@ -10,7 +10,7 @@
     * a [Minimum Viable Product (MVP)](MVP.md) for the standard with
       roughly the same functionality as [asm.js](http://asmjs.org), primarily
       aimed at [C/C++](CAndC++.md);
-    * [additional features :unicorn:][future general],
+    * [additional features 🦄][future general],
       initially focused on key features like [threads][future threads],
       [zero cost exceptions][future exceptions], and [SIMD][future simd],
       followed by additional features

--- a/JS.md
+++ b/JS.md
@@ -4,7 +4,7 @@
 
 In the [MVP](MVP.md), the only way to access WebAssembly on the Web is through
 an explicit JS API which is defined below.
-(In the [future :unicorn:][future general], WebAssembly may also
+(In the [future 🦄][future general], WebAssembly may also
 be loaded and run directly from an HTML `<script type='module'>` tag—and
 any other Web API that loads ES6 modules via URL—as part of 
 [ES6 Module integration](Modules.md#integration-with-es6-modules).)
@@ -658,7 +658,7 @@ Let `element` be the result of calling [`Get`](https://tc39.github.io/ecma262/#s
 If `element` is not the string `"anyfunc"`, a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror)
 is thrown.
 (Note: this check is intended to be relaxed in the
-[future :unicorn:][future types] to allow different element types.)
+[future 🦄][future types] to allow different element types.)
 
 Let `initial` be [`ToNonWrappingUint32`](#tononwrappinguint32)([`Get`](https://tc39.github.io/ecma262/#sec-get-o-p)(`tableDescriptor`, `"initial"`)).
 

--- a/MVP.md
+++ b/MVP.md
@@ -3,7 +3,7 @@
 As stated in the [high-level goals](HighLevelGoals.md), the first release aims
 at being a Minimum Viable Product (MVP). This means that there are important
 features we *know* we want and need, but are post-MVP; these are in a separate
-essential [post-MVP :unicorn:][future general] features document. The MVP will contain
+essential [post-MVP 🦄][future general] features document. The MVP will contain
 features which are available today in modern web browsers and which perform well
 even on mobile devices, which leads to roughly the same functionality as
 [asm.js](http://asmjs.org).

--- a/Modules.md
+++ b/Modules.md
@@ -6,7 +6,7 @@ with a set of import values to produce an **instance**, which is an immutable
 tuple referencing all the state accessible to the running module. Multiple
 module instances can access the same shared state which is the basis for 
 [dynamic linking](DynamicLinking.md) in WebAssembly. WebAssembly modules
-are also meant to integrate with ES6 modules in the [future :unicorn:][future modules].
+are also meant to integrate with ES6 modules in the [future 🦄][future modules].
 
 A module contains the following sections:
 
@@ -42,7 +42,7 @@ instantiation time, by the host environment. There are several kinds of imports:
 * **table imports**, which can be accessed inside the module by 
   [call_indirect](Semantics.md#calls) and other
   table operators in the 
-  [future :unicorn:][future types].
+  [future 🦄][future types].
 
 In the future, other kinds of imports may be added. Imports are designed to
 allow modules to share code and data while still allowing separate compilation
@@ -202,12 +202,12 @@ Each table definition declares an *element type*, *initial length*, and
 optional *maximum length*.
 
 In the MVP, the only valid element type is `"anyfunc"`, but in the
-[future :unicorn:][future types],
+[future 🦄][future types],
 more element types may be added.
 
 In the MVP, tables can only be resized via host-defined APIs (such as
 the JavaScript [`WebAssembly.Table.prototype.grow`](JS.md#webassemblytableprototypegrow)).
-A `grow_table` may be added in the [future :unicorn:][future types].
+A `grow_table` may be added in the [future 🦄][future types].
 In either case, table growth is guaranteed to fail if attempting to grow past
 the declared maximum. As with linear memory, when a maximum is declared,
 implementations *should* (non-normative) attempt to reserve virtual memory up to
@@ -287,7 +287,7 @@ by the memories defined within the module.
 The linear memory index space is only used by the 
 [data section](#data-section). In the MVP, there is at most one linear memory so
 this index space is just a placeholder for when there can be 
-[multiple memories :unicorn:][future multiple tables].
+[multiple memories 🦄][future multiple tables].
 
 ## Table Index Space
 
@@ -300,7 +300,7 @@ by the tables defined within the module.
 The table index space is only used by the [elements section](#elements-section).
 In the MVP, there is at most one table so this index space is just
 a placeholder for when there can be 
-[multiple tables :unicorn:][future multiple tables].
+[multiple tables 🦄][future multiple tables].
 
 ## Initializer Expression
 

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -18,7 +18,7 @@ currently admits nondeterminism:
  * New features will be added to WebAssembly, which means different implementations
    will have different support for each feature. This can be detected with
    `has_feature`, but is still a source of differences between executions.
- * [When threads are added as a feature :unicorn:][future threads], even without
+ * [When threads are added as a feature 🦄][future threads], even without
    shared memory, nondeterminism will be visible through the global sequence of
    API calls. With shared memory, the result of load operators is
    nondeterministic.
@@ -31,7 +31,7 @@ currently admits nondeterminism:
  * Except when otherwise specified, when an arithmetic operator with a floating
    point result type receives no NaN input values and produces a NaN result
    value, the sign bit of the NaN result value is nondeterministic.
- * [Fixed-width SIMD may want some flexibility :unicorn:][future simd]
+ * [Fixed-width SIMD may want some flexibility 🦄][future simd]
    - In SIMD.js, floating point values may or may not have subnormals flushed to
      zero.
    - In SIMD.js, operators ending in "Approximation" return approximations that

--- a/Rationale.md
+++ b/Rationale.md
@@ -194,7 +194,7 @@ flow). Alternative approaches can generate reducible control flow via node
 splitting, which can reduce throughput overhead, at the cost of increasing
 code size (potentially very significantly in pathological cases).
 Also,
-[more expressive control flow constructs :unicorn:][future flow control]
+[more expressive control flow constructs 🦄][future flow control]
 may be added in the future.
 
 ## Nop
@@ -456,8 +456,8 @@ hardware platforms.
 
 ## Motivating Scenarios for Feature Testing
 
-1. [Post-MVP :unicorn:][future general],
-[`i32.min_s` :unicorn:][future integer] is introduced. A
+1. [Post-MVP 🦄][future general],
+[`i32.min_s` 🦄][future integer] is introduced. A
 WebAssembly developer updates their toolkit so that the compiler may leverage
 `i32.min_s`. The developer's WebAssembly module works correctly both on
 execution environments at MVP, as well as those supporting `i32.min_s`.
@@ -469,7 +469,7 @@ possible, while at the same time providing them with the best experience
 possible. The developer has to balance the cost of the test matrix resulting
 from the combinations of possible feature configurations.
 
-2. [Post-MVP :unicorn:][future general], module authors may now use
+2. [Post-MVP 🦄][future general], module authors may now use
 [Threading][future threads]
 APIs in the browser. A developer wants to leverage multithreading in their
 module.

--- a/Security.md
+++ b/Security.md
@@ -108,7 +108,7 @@ valid functions declared at load time. Likewise, race conditions, such as
 [time of check to time of use][] (TOCTOU) vulnerabilities, are possible in
 WebAssembly, since no execution or scheduling guarantees are provided beyond
 in-order execution and [post-MVP atomic memory primitives
-:unicorn:][future threads].
+🦄][future threads].
 Similarly, [side channel attacks][] can occur, such as timing attacks against
 modules. In the future, additional protections may be provided by runtimes or
 the toolchain, such as code diversification or memory randomization (similar to

--- a/Semantics.md
+++ b/Semantics.md
@@ -33,7 +33,7 @@ on all modern computers. Each operator has a corresponding simple instruction.
 The [rationale](Rationale.md) document details why WebAssembly is designed as
 detailed in this document.
 
-[:unicorn:][future general] = Planned [future][future general] feature
+[🦄][future general] = Planned [future][future general] feature
 
 ## Traps
 
@@ -62,7 +62,7 @@ expected that WebAssembly will add some form of stack-introspection
 functionality, in which case such optimizations would be directly observable.
 
 Support for explicit tail calls is planned in
-[the future :unicorn:][future tail calls],
+[the future 🦄][future tail calls],
 which would add an explicit tail-call operator with well-defined effects
 on stack introspection.
 
@@ -106,7 +106,7 @@ Every WebAssembly [instance](Modules.md) has one specially-designated *default*
 linear memory which is the linear memory accessed by all the 
 [memory operators below](#linear-memory-access). In the MVP, there are *only*
 default linear memories but
-[new memory operators :unicorn:][future multiple tables]
+[new memory operators 🦄][future multiple tables]
 may be added after the MVP which can also access non-default memories.
 
 Linear memories (default or otherwise) can either be [imported](Modules.md#imports)
@@ -115,7 +115,7 @@ or definition, there is no difference when accessing a linear memory whether it
 was imported or defined internally.
 
 In the MVP, linear memory cannot be shared between threads of execution.
-The addition of [threads :unicorn:][future threads] will allow this.
+The addition of [threads 🦄][future threads] will allow this.
 
 ### Linear Memory Accesses
 
@@ -181,7 +181,7 @@ memory sizes are limited to 4 GiB (of course, actual sizes are further limited
 by [available resources](Nondeterminism.md)). In wasm64, address operands and
 offsets have type `i64`. The MVP only includes wasm32; subsequent versions
 will add support for wasm64 and thus
-[>4 GiB linear memory :unicorn:][future 64-bit].
+[>4 GiB linear memory 🦄][future 64-bit].
 
 ### Alignment
 
@@ -223,7 +223,7 @@ bytes are out of bounds, none of the bytes are modified.
 In the MVP, linear memory can be resized by a `grow_memory` operator. The
 operand to this operator is in units of the WebAssembly page size,
 which is defined to be 64KiB (though large page support may be added in
-the [future :unicorn:][future large pages]).
+the [future 🦄][future large pages]).
 
  * `grow_memory` : grow linear memory by a given unsigned delta of pages.
     Return the previous memory size in units of pages or -1 on failure.
@@ -241,14 +241,14 @@ The current size of the linear memory can be queried by the following operator:
 
 As stated [above](Semantics.md#linear-memory), linear memory is contiguous,
 meaning there are no "holes" in the linear address space. After the
-MVP, there are [future features :unicorn:][future memory control]
+MVP, there are [future features 🦄][future memory control]
 proposed to allow setting protection and creating mappings within the
 contiguous linear memory.
 
 In the MVP, memory can only be grown. After the MVP, a memory shrinking
 operator may be added. However, due to normal fragmentation, applications are
 instead expected release unused physical pages from the working set using the
-[`discard` :unicorn:][future memory control] future feature.
+[`discard` 🦄][future memory control] future feature.
 
 The above operators operate on the [default linear memory](#linear-memory).
 
@@ -288,7 +288,7 @@ to hold the array of indirectly-callable functions. Thus, in the MVP:
   this can only be done through the host environment (e.g., the `WebAssembly`
   [JavaScript API](JS.md#webassemblytable-objects)).
 
-These restrictions may be relaxed in the [future :unicorn:][future types].
+These restrictions may be relaxed in the [future 🦄][future types].
 
 ## Local variables
 
@@ -330,7 +330,7 @@ instantiation-time immutable values as a useful building block for
 
 After the MVP, when [reference types](GC.md) are added to the set of [value types](#types),
 global variables will be necessary to allow sharing reference types between
-[threads :unicorn:][future threads] since shared linear memory cannot load or store
+[threads 🦄][future threads] since shared linear memory cannot load or store
 references.
 
 ## Control constructs and instructions
@@ -541,7 +541,7 @@ Floating point arithmetic follows the IEEE 754-2008 standard, except that:
    supported.
 
 In the future, these limitations may be lifted, enabling
-[full IEEE 754-2008 support :unicorn:][future ieee 754].
+[full IEEE 754-2008 support 🦄][future ieee 754].
 
 Note that not all operators required by IEEE 754-2008 are provided directly.
 However, WebAssembly includes enough functionality to support reasonable library

--- a/Web.md
+++ b/Web.md
@@ -33,7 +33,7 @@ Note that it is expected that `compileStreaming` and `instantiateStreaming` be e
 
 #### `WebAssembly.compileStreaming`
 
-:cyclone: Added for milestone 2, developers must feature detect.
+🌀 Added for milestone 2, developers must feature detect.
 
 ```
 Promise<WebAssembly.Module> compileStreaming(source)
@@ -63,7 +63,7 @@ compilation fails, the returned promise will be rejected with a `WebAssembly.Com
 
 #### `WebAssembly.instantiateStreaming`
 
-:cyclone: Added for milestone 2, developers must feature detect.
+🌀 Added for milestone 2, developers must feature detect.
 
 ```
 dictionary WebAssemblyInstantiatedSource {


### PR DESCRIPTION
Fix broken GitHub emoji by changing them to roughly equivalent Unicode emoji.

I found the following broken emoji using the regex /:\w+?:/

- `unicorn` :unicorn:. Replaced with 🦄
- `star` :star:. Replaced with ⭐
- `cyclone` :cyclone:. Replaced with 🌀

These all render the same on Firefox/Ubuntu 18.04