### PR TITLE
Create w3spec.bib

### DIFF
--- a/w3spec.bib
+++ b/w3spec.bib
@@ -1,0 +1,8 @@
+@report{RossbergWebAssemblyCoreSpecification,
+  title = {{{WebAssembly Core Specification}}},
+  author = {Rossberg, Andreas},
+  date = {2019-12-05},
+  institution = {{W3C}},
+  url = {https://www.w3.org/TR/wasm-core-1/},
+  langid = {english}
+}


### PR DESCRIPTION
originally by @jendrikw, I just submitted the pull request. Does the bibtex item look fine? should the file be named w3spec.bib or maybe WASMStandard.bib or WASMSpec.bib or something like that?