### PR TITLE
FAQ: Change asm2wasm to past tense

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -70,8 +70,8 @@ polyfill.
 It is also the case that polyfilling WebAssembly to asm.js is less urgent
 because of the existence of alternatives, for example, a reverse polyfill -
 compiling
-[asm.js to WebAssembly](https://github.com/WebAssembly/binaryen/blob/master/src/asm2wasm.h) -
-exists, and it allows shipping a single build that can run as either
+[asm.js to WebAssembly](https://github.com/WebAssembly/binaryen/blob/version_96/src/asm2wasm.h) -
+existed, and it allows shipping a single build that can run as either
 asm.js or WebAssembly. It is also possible to build a project into
 two parallel asm.js and WebAssembly builds by just
 [flipping a switch](https://github.com/kripken/emscripten/wiki/WebAssembly)

--- a/FAQ.md
+++ b/FAQ.md
@@ -60,7 +60,7 @@ We think so. There was an early
 that decoding a binary WebAssembly-like format into asm.js can be efficient.
 And as the WebAssembly design has changed there have been
 [more](https://github.com/WebAssembly/polyfill-prototype-2)
-[experiments](https://github.com/WebAssembly/binaryen/blob/master/src/wasm2asm.h)
+[experiments](https://github.com/WebAssembly/binaryen/blob/master/src/wasm2js.h)
 with polyfilling.
 
 Overall, optimism has been increasing for quick adoption of WebAssembly in


### PR DESCRIPTION
binaryen has removed asm2wasm in version 97 (WebAssembly/binaryen#3042), since Emscripten stopped using it. Use a fixed-version link to minimize confusion, and change to past tense for good measure.

The https://webassembly.org/getting-started/advanced-tools/ also has a reference to the same link. I think that's the [website repo](https://github.com/WebAssembly/website).