### PR TITLE
Update references to IEEE 754-2008.

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -22,8 +22,8 @@ has an LP64 data model, meaning that `long` and pointer types will be
 added in the future to support
 [64-bit address spaces :unicorn:][future 64-bit].
 
-`float` and `double` are the IEEE 754-2008 single- and double-precision types,
-which are native in WebAssembly. `long double` is the IEEE 754-2008
+`float` and `double` are the IEEE 754-2019 single- and double-precision types,
+which are native in WebAssembly. `long double` is the IEEE 754-2019
 quad-precision type, which is a software-emulated type. WebAssembly does
 not have a builtin quad-precision type or associated operators. The long
 double type here is software-emulated in library code linked into WebAssembly
@@ -114,7 +114,7 @@ Most implementation-defined behavior in C and C++ is dependent on the compiler
 rather than on the underlying platform. For those details that are dependent
 on the platform, on WebAssembly they follow naturally from having 8-bit bytes,
 32-bit and 64-bit two's complement integers, and
-[32-bit and 64-bit IEEE-754-2008-style floating point support](Semantics.md#floating-point-operators).
+[32-bit and 64-bit IEEE-754-2019-style floating point support](Semantics.md#floating-point-operators).
 
 ## Portability of compiled code
 

--- a/Portability.md
+++ b/Portability.md
@@ -26,7 +26,7 @@ characteristics:
 * Support unaligned memory accesses or reliable trapping that allows software
   emulation thereof.
 * Two's complement signed integers in 32 bits and optionally 64 bits.
-* IEEE 754-2008 32-bit and 64-bit floating point, except for
+* IEEE 754-2019 32-bit and 64-bit floating point, except for
   [a few exceptions][floating-point operations].
 * Little-endian byte ordering.
 * Memory regions which can be efficiently addressed with 32-bit

--- a/Rationale.md
+++ b/Rationale.md
@@ -362,7 +362,7 @@ observed:
    it then be observed
 
 The motivation for nondeterminism in NaN bit patterns is that popular platforms
-have differing behavior. IEEE 754-2008 makes some recommendations, but has few
+have differing behavior. IEEE 754-2019 makes some recommendations, but has few
 hard requirements in this area, and in practice there is significant divergence,
 for example:
  - When an instruction with no NaN inputs produces a NaN output, x86 produces
@@ -377,13 +377,13 @@ for example:
  - LLVM (used in some WebAssembly implementations) doesn't guarantee that it
    won't commute `fadd`, `fmul` and other instructions, so it's not possible
    to rely on the "first" NaN being preserved as such.
- - IEEE 754-2008 itself recommends architectures use NaN bits to provide
+ - IEEE 754-2019 itself recommends architectures use NaN bits to provide
    architecture-specific debugging facilities.
 
-IEEE 754-2008 6.2 says that instructions returning a NaN *should* return one of
+IEEE 754-2019 6.2 says that instructions returning a NaN *should* return one of
 their input NaNs. In WebAssembly, implementations may do this, however they are
-not required to. Since IEEE 754-2008 states this as a "should" (as opposed to a
-"shall"), it isn't a requirement for IEEE 754-2008 conformance.
+not required to. Since IEEE 754-2019 states this as a "should" (as opposed to a
+"shall"), it isn't a requirement for IEEE 754-2019 conformance.
 
 An alternative design would be to require engines to always "canonicalize"
 NaNs whenever their bits could be observed. This would eliminate the


### PR DESCRIPTION
The current version of IEEE 754 is 754-2019. I've confirmed that the referenced section numbers are the same.