### PR TITLE
Update links.

### DIFF
--- a/CAndC++.md
+++ b/CAndC++.md
@@ -114,7 +114,7 @@ Most implementation-defined behavior in C and C++ is dependent on the compiler
 rather than on the underlying platform. For those details that are dependent
 on the platform, on WebAssembly they follow naturally from having 8-bit bytes,
 32-bit and 64-bit two's complement integers, and
-[32-bit and 64-bit IEEE-754-2019-style floating point support](Semantics.md#floating-point-operators).
+[32-bit and 64-bit IEEE-754-2019-style floating point support](https://webassembly.github.io/spec/core/exec/numerics.html#floating-point).
 
 ## Portability of compiled code
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -189,7 +189,7 @@ The [LLVM](https://llvm.org/) compiler infrastructure has a lot of attractive
 qualities: it has an existing intermediate representation (LLVM IR) and binary
 encoding format (bitcode). It has code generation backends targeting many 
 architectures and is actively developed and maintained by a large community. In
-fact [PNaCl](http://gonacl.com) already uses LLVM as a basis for its binary
+fact PNaCl already uses LLVM as a basis for its binary
 format. However, the goals and requirements that LLVM was designed to meet are
 subtly mismatched with those of WebAssembly.
 
@@ -311,11 +311,11 @@ syscall in POSIX, WebAssembly unpacks this functionality into multiple
 operators:
 
 * the MVP starts with the ability to grow linear memory via a
-  [`grow_memory`](Semantics.md#resizing) operator;
+  [`memory.grow`] operator;
 * proposed
   [future features :unicorn:][future memory control] would
   allow the application to change the protection and mappings for pages in the
-  contiguous range `0` to `memory_size`.
+  contiguous range `0` to `memory.size`.
 
 A significant feature of `mmap` that is missing from the above list is the
 ability to allocate disjoint virtual address ranges. The reasoning for this
@@ -394,3 +394,4 @@ Android / iOS.
 [future garbage collection]: https://github.com/WebAssembly/proposals/issues/16
 [future floating point]: https://github.com/WebAssembly/design/issues/1391
 [future memory control]: https://github.com/WebAssembly/memory-control
+[`memory.grow`]: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory

--- a/NonWeb.md
+++ b/NonWeb.md
@@ -22,7 +22,7 @@ JavaScript VM present.
 The WebAssembly spec itself will not try to define any large portable libc-like
 library. However, certain features that are core to WebAssembly semantics that
 are similar to functions found in native libc *would* be part of the core
-WebAssembly spec as primitive operators (e.g., the `grow_memory` operator, which
+WebAssembly spec as primitive operators (e.g., the `memory.grow` operator, which
 is similar to the `sbrk` function on many systems, and in the future, operators
 similar to `dlopen`).
 

--- a/Rationale.md
+++ b/Rationale.md
@@ -133,8 +133,8 @@ WebAssembly engines.
 In the future, WebAssembly may offer the ability to use larger page sizes on
 some platforms for increased TLB efficiency.
 
-The `grow_memory` operator returns the old memory size. This is desirable for
-using `grow_memory` independently on multiple threads, so that each thread can
+The `memory.grow` operator returns the old memory size. This is desirable for
+using `memory.grow` independently on multiple threads, so that each thread can
 know where the region it allocated starts. The obvious alternative would be for
 such threads to communicate manually, however WebAssembly implementations will likely
 already be communicating between threads in order to properly allocate the sum


### PR DESCRIPTION
Update some URLs and opcode names to fix broken links.

gonacl.com appears to be a parked domain at this time.