### PR TITLE
Update README.md, Nondeterminism.md, and Security.md

### DIFF
--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -17,7 +17,8 @@ currently admits nondeterminism:
 
  * New features will be added to WebAssembly, which means different implementations
    will have different support for each feature.
- * The sequence of call of exported functions from the outside environment is not
+ * The sequence of calls of exported functions, and the values of the incoming
+   arguments and return values from the outside environment, are not
    determined by the Wasm spec.
  * With `shared` memory that can be accessed by multiple threads, the results of
    load, read-modify-write, wait, and awake operators are nondeterministic.

--- a/Nondeterminism.md
+++ b/Nondeterminism.md
@@ -16,12 +16,11 @@ The following is a list of the places where the WebAssembly specification
 currently admits nondeterminism:
 
  * New features will be added to WebAssembly, which means different implementations
-   will have different support for each feature. This can be detected with
-   `has_feature`, but is still a source of differences between executions.
- * [When threads are added as a feature :unicorn:][future threads], even without
-   shared memory, nondeterminism will be visible through the global sequence of
-   API calls. With shared memory, the result of load operators is
-   nondeterministic.
+   will have different support for each feature.
+ * The sequence of call of exported functions from the outside environment is not
+   determined by the Wasm spec.
+ * With `shared` memory that can be accessed by multiple threads, the results of
+   load, read-modify-write, wait, and awake operators are nondeterministic.
  * Except when otherwise specified, when an arithmetic operator returns NaN,
    there is nondeterminism in determining the specific bits of the NaN. However,
    wasm does still provide the guarantee that NaN values returned from an operation
@@ -31,11 +30,7 @@ currently admits nondeterminism:
  * Except when otherwise specified, when an arithmetic operator with a floating
    point result type receives no NaN input values and produces a NaN result
    value, the sign bit of the NaN result value is nondeterministic.
- * [Fixed-width SIMD may want some flexibility :unicorn:][future simd]
-   - In SIMD.js, floating point values may or may not have subnormals flushed to
-     zero.
-   - In SIMD.js, operators ending in "Approximation" return approximations that
-     may vary between platforms.
+ * The [relaxed SIMD] instructions have nondeterministic results.
  * Environment-dependent resource limits may be exhausted. A few examples:
    - Memory allocation may fail.
    - The runtime can fail to allocate a physical page when a memory location is first
@@ -47,10 +42,14 @@ currently admits nondeterminism:
    - Resources such as handles may get exhausted.
    - Any other resource could get exhausted at any time. Caveat emptor.
 
+The following proposals would add additional nondeterminism:
+
+ * [Flexible-vectors], adding nondeterminism in the length of the vectors.
+
 Users of C, C++, and similar languages should be aware that operators which
 have defined or constrained behavior in WebAssembly itself may nonetheless still
 have undefined behavior
 [at the source code level](CAndC++.md#undefined-behavior).
 
-[future threads]: https://github.com/WebAssembly/design/issues/1073
-[future simd]: https://github.com/WebAssembly/design/issues/1075
+[relaxed SIMD]: https://github.com/WebAssembly/relaxed-simd
+[Flexible-vectors]: https://github.com/WebAssembly/flexible-vectors

--- a/README.md
+++ b/README.md
@@ -1,51 +1,31 @@
 # WebAssembly Design
 
-This repository contains documents describing the design and high-level overview of WebAssembly.
+This repository is part of the [WebAssembly Community Group] and hosts the
+[issue tracker] for [phase 0 proposals], a [discussion forum] for questions
+and general discussion, and a collection of high-level non-normative
+[design documents].
 
-The documents and discussions in this repository are part of the [WebAssembly Community Group](https://www.w3.org/community/webassembly/).
+For more information about WebAssembly itself, see [the website]! For
+information about Contributing to WebAssembly see [the Contributing document].
 
-## Overview
+Please follow our [Code of Ethics and Professional Conduct].
 
-WebAssembly or wasm is a new, portable, size- and load-time-efficient format suitable for compilation to the web.
+## Design documents
 
-WebAssembly is currently being designed as an open standard by a [W3C Community Group](https://www.w3.org/community/webassembly/) that includes representatives from all major browsers. *Expect the contents of this repository to be in flux: everything is still under discussion.*
+Some of the design documents in this repository are out of date. We're
+gradually working updating these documents. The following are some documents
+which are fairly up to date:
 
-- **WebAssembly is efficient and fast**: Wasm [bytecode](Semantics.md) is designed to be encoded in a size- and load-time-efficient [binary format](BinaryEncoding.md). WebAssembly aims to execute at native speed by taking advantage of [common hardware capabilities](Portability.md#assumptions-for-efficient-execution) available on a wide range of platforms.
+ - [What does Portability mean in Wasm?](Portability.md)
+ - [Design Rationale](Rationale.md)
+ - [WebAssembly's Security model](Security.md)
+ - [Nondeterminism in WebAssembly](Nondeterminism.md)
 
-- **WebAssembly is safe**: WebAssembly describes a [memory-safe](Security.md#memory-safety), sandboxed [execution environment](Semantics.md#linear-memory) that may even be implemented inside existing JavaScript virtual machines.  When [embedded in the web](Web.md), WebAssembly will enforce the same-origin and permissions security policies of the browser.
-
-- **WebAssembly is open and debuggable**: WebAssembly is designed to be pretty-printed in a [textual format](TextFormat.md) for debugging, testing, experimenting, optimizing, learning, teaching, and writing programs by hand. The textual format will be used when [viewing the source](FAQ.md#will-webassembly-support-view-source-on-the-web) of wasm modules on the web.
-
-- **WebAssembly is part of the open web platform**: WebAssembly is designed to maintain the versionless, feature-tested, and backwards-compatible [nature of the web](Web.md). WebAssembly modules will be able to call into and out of the JavaScript context and access browser functionality through the same Web APIs accessible from JavaScript. WebAssembly also supports [non-web](NonWeb.md) embeddings.
-
-## More Information
-
-| Resource                                   | Repository Location      |
-|--------------------------------------------|--------------------------|
-| High Level Goals                           | [design/HighLevelGoals.md](HighLevelGoals.md) |
-| Frequently Asked Questions                 | [design/FAQ.md](FAQ.md)            |
-| Language Specification                     | [spec/README.md](https://github.com/WebAssembly/spec)           |
-
-## Design Process & Contributing
-
-The WebAssembly specification is being developed in the [spec repository](https://github.com/WebAssembly/spec/). For now, high-level design discussions should continue to be held in the design repository, via issues and pull requests, so that the specification work can remain focused.
-
-We've mapped out features we expect to ship:
-
- 1. An initial [Minimum Viable Product (MVP)](MVP.md) release;
- 2. And soon after in [future versions][future general].
-
-Join us:
-
- * In the [W3C Community Group](https://www.w3.org/community/webassembly/)
- 
-     * Its moderated [announcement mailing list](https://lists.w3.org/Archives/Public/public-webassembly-announce/)
-     * Its [open-ended public discussion mailing list](https://lists.w3.org/Archives/Public/public-webassembly/)
-
- * On IRC: `irc://irc.w3.org:6667/#webassembly`
- * On Stack Overflow's [#webassembly tag](https://stackoverflow.com/questions/tagged/webassembly#)
- * By [contributing](Contributing.md)!
-
-When contributing, please follow our [Code of Ethics and Professional Conduct](CodeOfConduct.md).
-
-[future general]: FutureFeatures.md
+[issue tracker]: https://github.com/WebAssembly/design/issues
+[phase 0 proposals]: https://github.com/WebAssembly/meetings/blob/main/process/phases.md#0-pre-proposal-individual-contributor
+[discussion forum]: https://github.com/WebAssembly/design/discussions
+[the Contributing document]: Contributing.md
+[the website]: https://webassembly.org
+[Code of Ethics and Professional Conduct]: https://github.com/WebAssembly/meetings/blob/main/CODE_OF_CONDUCT.md
+[design documents]: #design-documents
+[WebAssembly Community Group]: https://www.w3.org/community/webassembly/

--- a/Security.md
+++ b/Security.md
@@ -56,10 +56,11 @@ operator, or are of type `struct` and returned by value) are stored in a separat
 user-addressable stack in [linear memory](Semantics.md#linear-memory) at
 compile time. This is an isolated memory region with fixed maximum size that is
 zero initialized by default. References to this memory are computed with
-infinite precision to avoid wrapping and simplify bounds checking. In the future,
-support for [multiple linear memory sections](Modules.md#linear-memory-section) and
+infinite precision to avoid wrapping and simplify bounds checking. WebAssembly
+modules may also have [multiple linear memory sections], which are independent
+of each other. In the future,
 [finer-grained memory operations][future memory control]
-(e.g. shared memory, page protection, large pages, etc.) will be implemented.
+(e.g. shared memory, page protection, large pages, etc.) may be implemented.
 
 [Traps](Semantics.md#traps) are used to immediately terminate execution and
 signal abnormal behavior to the execution environment. In a browser, this is
@@ -107,8 +108,7 @@ in WebAssembly, because control-flow integrity ensures that call targets are
 valid functions declared at load time. Likewise, race conditions, such as
 [time of check to time of use][] (TOCTOU) vulnerabilities, are possible in
 WebAssembly, since no execution or scheduling guarantees are provided beyond
-in-order execution and [post-MVP atomic memory primitives
-:unicorn:][future threads].
+in-order execution and [atomic memory primitives][threads].
 Similarly, [side channel attacks][] can occur, such as timing attacks against
 modules. In the future, additional protections may be provided by runtimes or
 the toolchain, such as code diversification or memory randomization (similar to
@@ -151,8 +151,8 @@ attacks with function-level granularity against indirect calls.
 #### Clang/LLVM CFI
 The Clang/LLVM compiler infrastructure includes a [built-in implementation] of
 fine-grained control flow integrity, which has been extended to support the
-WebAssembly target. It is available in Clang/LLVM 3.9+ with the
-[new WebAssembly backend].
+WebAssembly target. It is available in Clang/LLVM with the
+[WebAssembly backend].
 
 Enabling fine-grained control-flow integrity (by passing `-fsanitize=cfi` to
 emscripten) has a number of advantages over the default WebAssembly
@@ -162,9 +162,9 @@ signature checks by operating at the C/C++ type level, which is semantically
 richer that the WebAssembly [type level](Semantics.md#types), which consists
 of only four value types. Currently, enabling this feature has a small
 performance cost for each indirect call, because an integer range check is
-used to verify that the target index is trusted, but this will be eliminated in
+used to verify that the target index is trusted, but this may be eliminated in
 the future by leveraging built-in support for
-[multiple indirect tables](Modules.md#table-index-space) with homogeneous type
+[multiple indirect tables] with homogeneous type
 in WebAssembly.
 
   [address space layout randomization]: https://en.wikipedia.org/wiki/Address_space_layout_randomization
@@ -180,5 +180,7 @@ in WebAssembly.
   [stack smashing protection]: https://en.wikipedia.org/wiki/Buffer_overflow_protection#Random_canaries
   [time of check to time of use]: https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use
 
-[future threads]: https://github.com/WebAssembly/design/issues/1073
+[multiple linear memory sections]: https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md
+[multiple indirect tables]: https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md
+[threads]: https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md
 [future memory control]: https://github.com/WebAssembly/memory-control


### PR DESCRIPTION
Rewrite README.md to reflect the design repo's current purposes and update outdated information. Also, remove text from README.md which now lives in the webassembly.org website, and link to the website instead.

Also, update some outdated information and links in Nondeterminism and Security.md, so that we can link to them as examples of fairly current documents.